### PR TITLE
Add rectangular synthetic and real-world dataset evaluation scripts

### DIFF
--- a/Examples/_rectangular_tw_common.py
+++ b/Examples/_rectangular_tw_common.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import LogNorm
+
+from mheatmap import mosaic_heatmap
+
+
+def diagonal_band_mass(matrix: np.ndarray, frac: float) -> float:
+    total = float(matrix.sum())
+    if total <= 0:
+        return 0.0
+
+    n_rows, n_cols = matrix.shape
+    band = max(1, int(frac * min(n_rows, n_cols)))
+    score = 0.0
+
+    for row_index in range(n_rows):
+        center = row_index * n_cols / n_rows
+        start = max(0, int(np.floor(center - band)))
+        stop = min(n_cols, int(np.ceil(center + band + 1)))
+        score += float(matrix[row_index, start:stop].sum())
+
+    return score / total
+
+
+def recover_column_labels(
+    original_matrix: np.ndarray,
+    original_row_labels: np.ndarray,
+    original_col_labels: np.ndarray,
+    reordered_matrix: np.ndarray,
+    reordered_row_labels: np.ndarray,
+) -> np.ndarray:
+    row_lookup = {label: index for index, label in enumerate(original_row_labels)}
+    row_order = np.array(
+        [row_lookup[label] for label in reordered_row_labels],
+        dtype=int,
+    )
+    row_reordered_original = original_matrix[row_order, :]
+
+    column_lookup: dict[bytes, list[int]] = defaultdict(list)
+    for col_index in range(row_reordered_original.shape[1]):
+        key = np.ascontiguousarray(row_reordered_original[:, col_index]).tobytes()
+        column_lookup[key].append(col_index)
+
+    recovered_indices = []
+    for col_index in range(reordered_matrix.shape[1]):
+        key = np.ascontiguousarray(reordered_matrix[:, col_index]).tobytes()
+        matches = column_lookup[key]
+        if not matches:
+            raise ValueError("Could not recover reordered column labels from matrix.")
+        recovered_indices.append(matches.pop(0))
+
+    return original_col_labels[np.array(recovered_indices, dtype=int)]
+
+
+def maybe_ticklabels(labels: np.ndarray, max_labels: int = 40):
+    return labels if len(labels) <= max_labels else False
+
+
+def write_matrix_csv_fast(
+    path: Path,
+    matrix: np.ndarray,
+    row_labels: np.ndarray,
+    col_labels: np.ndarray,
+) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["row_label", *list(col_labels)])
+        rounded = np.rint(matrix)
+        use_int = np.allclose(matrix, rounded)
+        for label, row, rounded_row in zip(row_labels, matrix, rounded, strict=True):
+            values = rounded_row.astype(int) if use_int else row
+            writer.writerow([label, *values.tolist()])
+
+
+def write_metadata_csv(
+    path: Path,
+    header: tuple[str, ...],
+    rows: list[tuple[object, ...]],
+) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def plot_triptych(
+    original_matrix: np.ndarray,
+    tw_matrix: np.ndarray,
+    original_row_labels: np.ndarray,
+    original_col_labels: np.ndarray,
+    tw_row_labels: np.ndarray,
+    tw_col_labels: np.ndarray,
+    output_path: Path,
+    figure_title: str,
+    subtitle: str,
+    colorbar_label: str,
+    cmap: str = "YlGnBu",
+    band_frac: float = 0.12,
+    mask_below: float = 0.0,
+) -> None:
+    scale_values = np.concatenate(
+        [
+            original_matrix[original_matrix > mask_below],
+            tw_matrix[tw_matrix > mask_below],
+        ]
+    )
+    if scale_values.size == 0:
+        raise ValueError("Cannot plot an all-zero matrix.")
+
+    norm = LogNorm(vmin=float(scale_values.min()), vmax=float(scale_values.max()))
+    original_masked = np.ma.masked_where(
+        original_matrix <= mask_below,
+        original_matrix,
+    )
+    tw_masked = np.ma.masked_where(tw_matrix <= mask_below, tw_matrix)
+
+    fig, axes = plt.subplots(1, 3, figsize=(22, 8), constrained_layout=True)
+
+    panels = [
+        ("Original", original_masked, original_row_labels, original_col_labels),
+        (
+            "TW Spectral Reordered",
+            tw_masked,
+            tw_row_labels,
+            tw_col_labels,
+        ),
+    ]
+
+    for ax, (title, matrix, row_labels, col_labels) in zip(
+        axes[:2], panels, strict=True
+    ):
+        image = ax.imshow(
+            matrix,
+            aspect="auto",
+            interpolation="nearest",
+            cmap=cmap,
+            norm=norm,
+        )
+        ax.set_title(title, fontsize=18, color="#4A4A4A")
+        xlabels = maybe_ticklabels(col_labels)
+        ylabels = maybe_ticklabels(row_labels)
+        if xlabels is False:
+            ax.set_xticks([])
+        else:
+            ax.set_xticks(np.arange(len(col_labels)))
+            ax.set_xticklabels(xlabels, rotation=90, fontsize=7)
+            ax.xaxis.set_ticks_position("top")
+        if ylabels is False:
+            ax.set_yticks([])
+        else:
+            ax.set_yticks(np.arange(len(row_labels)))
+            ax.set_yticklabels(ylabels, fontsize=7)
+        ax.set_xlabel("Columns")
+        ax.set_ylabel("Rows")
+        ax.tick_params(colors="#4A4A4A")
+        fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+
+    axes[2].set_title("TW Spectral Reordered + Mosaic", fontsize=18, color="#4A4A4A")
+    mosaic_heatmap(
+        tw_matrix,
+        ax=axes[2],
+        xticklabels=maybe_ticklabels(tw_col_labels),
+        yticklabels=maybe_ticklabels(tw_row_labels),
+        cmap=cmap,
+        mask=tw_matrix <= mask_below,
+        norm=norm,
+        cbar=True,
+        cbar_kws={"label": colorbar_label},
+        rasterized=True,
+    )
+    axes[2].tick_params(colors="#4A4A4A")
+    axes[2].xaxis.set_ticks_position("top")
+    axes[2].set_xlabel("Columns")
+    axes[2].set_ylabel("Rows")
+
+    original_score = diagonal_band_mass(original_matrix, band_frac)
+    tw_score = diagonal_band_mass(tw_matrix, band_frac)
+    score_text = (
+        f"Diagonal-band mass: original={original_score:.3f}, "
+        f"tw={tw_score:.3f}"
+    )
+    fig.suptitle(
+        f"{figure_title}\n{subtitle}\n{score_text}",
+        y=1.02,
+        fontsize=14,
+    )
+    fig.savefig(output_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)

--- a/Examples/acs_pums_rectangular/demo_tw_mosaic.py
+++ b/Examples/acs_pums_rectangular/demo_tw_mosaic.py
@@ -1,0 +1,263 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+sys.modules.setdefault("numexpr", None)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+EXAMPLES_DIR = REPO_ROOT / "Examples"
+for path in (SRC_DIR, EXAMPLES_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from mheatmap.graph import spectral_permute
+
+from _rectangular_tw_common import (
+    diagonal_band_mass,
+    plot_triptych,
+    recover_column_labels,
+    write_matrix_csv_fast,
+    write_metadata_csv,
+)
+
+RAW_DIR = REPO_ROOT / "data" / "acs_pums_rectangular" / "raw"
+PROCESSED_DIR = REPO_ROOT / "data" / "acs_pums_rectangular" / "processed"
+FIGURES_DIR = REPO_ROOT / "data" / "acs_pums_rectangular" / "figures"
+
+SOURCE_URL = "https://www2.census.gov/programs-surveys/acs/data/pums/2023/1-Year/csv_pma.zip"
+RAW_FILENAME = "csv_pma.zip"
+CSV_MEMBER = "psam_p25.csv"
+OUTPUT_STEM = "acs2023_ma_occp_indp"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download ACS 2023 Massachusetts PUMS, build an occupation-by-industry "
+            "matrix from weighted person records, select a low-entropy rectangular "
+            "submatrix, and compare original / TW / TW+mosaic views."
+        )
+    )
+    parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--show", action="store_true")
+    return parser.parse_args()
+
+
+def ensure_directories() -> None:
+    for directory in (RAW_DIR, PROCESSED_DIR, FIGURES_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def download_source(refresh: bool) -> Path:
+    path = RAW_DIR / RAW_FILENAME
+    if refresh or not path.exists():
+        path.unlink(missing_ok=True)
+        urllib.request.urlretrieve(SOURCE_URL, path)
+    return path
+
+
+def load_person_data(path: Path) -> pd.DataFrame:
+    with zipfile.ZipFile(path) as archive:
+        with archive.open(CSV_MEMBER) as handle:
+            df = pd.read_csv(handle, usecols=["ESR", "OCCP", "INDP", "PWGTP"])
+
+    df = df[df["ESR"].isin([1, 2])].dropna(subset=["OCCP", "INDP", "PWGTP"]).copy()
+    df["OCCP"] = df["OCCP"].astype(int).astype(str).str.zfill(4)
+    df["INDP"] = df["INDP"].astype(int).astype(str).str.zfill(4)
+    return df
+
+
+def find_best_submatrix(
+    matrix_df: pd.DataFrame,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, pd.DataFrame, pd.DataFrame]:
+    matrix = matrix_df.to_numpy(dtype=float)
+    row_labels = matrix_df.index.to_numpy()
+    col_labels = matrix_df.columns.to_numpy()
+
+    row_totals = matrix.sum(axis=1)
+    sorted_values = np.sort(matrix, axis=1)
+    top2_share = (sorted_values[:, -1] + sorted_values[:, -2]) / row_totals
+    best = None
+
+    for min_total in (200, 500, 1000, 2000, 4000):
+        for min_top2_share in (0.70, 0.75, 0.80, 0.85, 0.90):
+            keep_rows = (row_totals >= min_total) & (top2_share >= min_top2_share)
+            if keep_rows.sum() < 12:
+                continue
+
+            reduced = matrix[keep_rows]
+            reduced_row_labels = row_labels[keep_rows]
+            dominant_columns = np.argsort(reduced.sum(axis=0))[::-1]
+
+            for n_cols in (10, 12, 15, 18, 20):
+                if n_cols >= reduced.shape[1]:
+                    continue
+
+                col_indices = dominant_columns[:n_cols]
+                reduced_cols = reduced[:, col_indices]
+                active_rows = reduced_cols.sum(axis=1) > 0
+                reduced_cols = reduced_cols[active_rows]
+                reduced_row_labels_2 = reduced_row_labels[active_rows]
+                if reduced_cols.shape[0] < n_cols + 4 or reduced_cols.shape[0] > 40:
+                    continue
+
+                row_mass = reduced_cols.sum(axis=1)
+                row_sorted = np.sort(reduced_cols, axis=1)
+                row_share = (row_sorted[:, -1] + row_sorted[:, -2]) / row_mass
+                candidate_order = np.argsort(-(row_mass * row_share))
+
+                for n_rows in (18, 20, 24, 28, 32, 36):
+                    if n_rows > reduced_cols.shape[0] or n_rows == n_cols:
+                        continue
+
+                    row_indices = candidate_order[:n_rows]
+                    candidate = reduced_cols[row_indices].astype(float)
+                    candidate_rows = reduced_row_labels_2[row_indices]
+                    candidate_cols = col_labels[col_indices]
+
+                    tw_matrix, tw_row_labels = spectral_permute(
+                        candidate,
+                        candidate_rows,
+                        mode="tw",
+                    )
+                    tw_score = diagonal_band_mass(tw_matrix, frac=0.12)
+                    original_score = diagonal_band_mass(candidate, frac=0.12)
+                    score = (
+                        tw_score,
+                        tw_score - original_score,
+                        candidate.shape[0] * candidate.shape[1],
+                    )
+
+                    if best is None or score > best["score"]:
+                        best = {
+                            "score": score,
+                            "matrix": candidate,
+                            "row_labels": candidate_rows,
+                            "col_labels": candidate_cols,
+                            "original_score": original_score,
+                            "tw_score": tw_score,
+                        }
+
+    if best is None:
+        raise RuntimeError("Could not find a satisfactory ACS PUMS submatrix.")
+
+    row_meta = pd.DataFrame(
+        {
+            "occp": best["row_labels"],
+            "weighted_total": best["matrix"].sum(axis=1).astype(int),
+            "top2_share": np.round(
+                (
+                    np.sort(best["matrix"], axis=1)[:, -1]
+                    + np.sort(best["matrix"], axis=1)[:, -2]
+                )
+                / best["matrix"].sum(axis=1),
+                4,
+            ),
+        }
+    )
+    col_meta = pd.DataFrame(
+        {
+            "indp": best["col_labels"],
+            "weighted_total": best["matrix"].sum(axis=0).astype(int),
+        }
+    )
+    return (
+        best["matrix"],
+        best["row_labels"],
+        best["col_labels"],
+        row_meta,
+        col_meta,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_directories()
+    source_path = download_source(args.refresh)
+
+    person_df = load_person_data(source_path)
+    matrix_df = person_df.pivot_table(
+        index="OCCP",
+        columns="INDP",
+        values="PWGTP",
+        aggfunc="sum",
+        fill_value=0,
+    )
+    original_matrix, row_labels, col_labels, row_meta, col_meta = find_best_submatrix(
+        matrix_df
+    )
+    tw_matrix, tw_row_labels = spectral_permute(
+        original_matrix,
+        row_labels,
+        mode="tw",
+    )
+    tw_col_labels = recover_column_labels(
+        original_matrix,
+        row_labels,
+        col_labels,
+        tw_matrix,
+        tw_row_labels,
+    )
+
+    write_matrix_csv_fast(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_original_matrix.csv",
+        original_matrix,
+        row_labels,
+        col_labels,
+    )
+    write_matrix_csv_fast(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_tw_matrix.csv",
+        tw_matrix,
+        tw_row_labels,
+        tw_col_labels,
+    )
+    write_metadata_csv(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_row_metadata.csv",
+        ("occp", "weighted_total", "top2_share"),
+        [tuple(row) for row in row_meta.itertuples(index=False, name=None)],
+    )
+    write_metadata_csv(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_col_metadata.csv",
+        ("indp", "weighted_total"),
+        [tuple(row) for row in col_meta.itertuples(index=False, name=None)],
+    )
+
+    figure_path = FIGURES_DIR / f"{OUTPUT_STEM}_original_vs_tw_vs_tw_mosaic.png"
+    plot_triptych(
+        original_matrix=original_matrix,
+        tw_matrix=tw_matrix,
+        original_row_labels=row_labels,
+        original_col_labels=col_labels,
+        tw_row_labels=tw_row_labels,
+        tw_col_labels=tw_col_labels,
+        output_path=figure_path,
+        figure_title="ACS 2023 Massachusetts PUMS",
+        subtitle=(
+            f"{original_matrix.shape[0]} occupation codes x "
+            f"{original_matrix.shape[1]} industry codes, "
+            f"weighted by PWGTP"
+        ),
+        colorbar_label="Weighted person count",
+        mask_below=175,
+    )
+
+    if args.show:
+        image = plt.imread(figure_path)
+        plt.figure(figsize=(18, 8))
+        plt.imshow(image)
+        plt.axis("off")
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/lodes_rectangular/demo_tw_mosaic.py
+++ b/Examples/lodes_rectangular/demo_tw_mosaic.py
@@ -1,0 +1,282 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.request
+from pathlib import Path
+
+sys.modules.setdefault("numexpr", None)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+EXAMPLES_DIR = REPO_ROOT / "Examples"
+for path in (SRC_DIR, EXAMPLES_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from mheatmap.graph import spectral_permute
+
+from _rectangular_tw_common import (
+    diagonal_band_mass,
+    plot_triptych,
+    recover_column_labels,
+    write_matrix_csv_fast,
+    write_metadata_csv,
+)
+
+RAW_DIR = REPO_ROOT / "data" / "lodes_rectangular" / "raw"
+PROCESSED_DIR = REPO_ROOT / "data" / "lodes_rectangular" / "processed"
+FIGURES_DIR = REPO_ROOT / "data" / "lodes_rectangular" / "figures"
+
+OD_URL = "https://lehd.ces.census.gov/data/lodes/LODES8/tn/od/tn_od_main_JT00_2022.csv.gz"
+XWALK_URL = "https://lehd.ces.census.gov/data/lodes/LODES8/tn/tn_xwalk.csv.gz"
+OD_FILENAME = "tn_od_main_JT00_2022.csv.gz"
+XWALK_FILENAME = "tn_xwalk.csv.gz"
+OUTPUT_STEM = "tn_lodes2022_home_county_to_work_county"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download Tennessee LODES8 OD data, aggregate to a home-county by "
+            "work-county matrix, select a low-entropy commuting submatrix, and "
+            "compare original / TW / TW+mosaic views."
+        )
+    )
+    parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--show", action="store_true")
+    return parser.parse_args()
+
+
+def ensure_directories() -> None:
+    for directory in (RAW_DIR, PROCESSED_DIR, FIGURES_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def download_source(url: str, filename: str, refresh: bool) -> Path:
+    path = RAW_DIR / filename
+    if refresh or not path.exists():
+        path.unlink(missing_ok=True)
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def load_county_matrix(od_path: Path) -> pd.DataFrame:
+    od_df = pd.read_csv(od_path, usecols=["w_geocode", "h_geocode", "S000"])
+    od_df["w_county"] = od_df["w_geocode"].astype(str).str.zfill(15).str[:5]
+    od_df["h_county"] = od_df["h_geocode"].astype(str).str.zfill(15).str[:5]
+    county_df = od_df.groupby(["h_county", "w_county"], as_index=False)["S000"].sum()
+    return county_df.pivot_table(
+        index="h_county",
+        columns="w_county",
+        values="S000",
+        aggfunc="sum",
+        fill_value=0,
+    )
+
+
+def load_county_names(path: Path) -> dict[str, str]:
+    xwalk = pd.read_csv(path, usecols=["cty", "ctyname"]).drop_duplicates(
+        subset=["cty"]
+    )
+    xwalk["cty"] = xwalk["cty"].astype(str).str.zfill(5)
+    return dict(xwalk[["cty", "ctyname"]].itertuples(index=False, name=None))
+
+
+def find_best_submatrix(
+    matrix_df: pd.DataFrame,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, pd.DataFrame, pd.DataFrame]:
+    matrix = matrix_df.to_numpy(dtype=float)
+    row_labels = matrix_df.index.to_numpy()
+    col_labels = matrix_df.columns.to_numpy()
+
+    row_totals = matrix.sum(axis=1)
+    sorted_values = np.sort(matrix, axis=1)
+    top2_share = (sorted_values[:, -1] + sorted_values[:, -2]) / row_totals
+    best = None
+
+    for min_total in (5000, 10000, 20000, 50000):
+        keep_rows = (row_totals >= min_total) & (top2_share >= 0.70)
+        if keep_rows.sum() < 8:
+            continue
+
+        reduced = matrix[keep_rows]
+        reduced_row_labels = row_labels[keep_rows]
+        dominant_columns = np.argsort(reduced.sum(axis=0))[::-1]
+
+        for n_cols in (4, 5, 6, 7, 8, 10):
+            if n_cols >= reduced.shape[1]:
+                continue
+
+            col_indices = dominant_columns[:n_cols]
+            candidate_cols = reduced[:, col_indices]
+            row_mass = candidate_cols.sum(axis=1)
+            row_sorted = np.sort(candidate_cols, axis=1)
+            row_share = (row_sorted[:, -1] + row_sorted[:, -2]) / row_mass
+            candidate_order = np.argsort(-(row_mass * row_share))
+
+            for n_rows in (10, 12, 15, 18, 20, 24, 28):
+                if n_rows > candidate_cols.shape[0] or n_rows == n_cols:
+                    continue
+
+                row_indices = candidate_order[:n_rows]
+                candidate = candidate_cols[row_indices].astype(float)
+                candidate_rows = reduced_row_labels[row_indices]
+                candidate_col_labels = col_labels[col_indices]
+
+                tw_matrix, tw_row_labels = spectral_permute(
+                    candidate,
+                    candidate_rows,
+                    mode="tw",
+                )
+                tw_score = diagonal_band_mass(tw_matrix, frac=0.18)
+                original_score = diagonal_band_mass(candidate, frac=0.18)
+                score = (
+                    tw_score,
+                    tw_score - original_score,
+                    candidate.shape[0] * candidate.shape[1],
+                )
+
+                if best is None or score > best["score"]:
+                    best = {
+                        "score": score,
+                        "matrix": candidate,
+                        "row_labels": candidate_rows,
+                        "col_labels": candidate_col_labels,
+                    }
+
+    if best is None:
+        raise RuntimeError("Could not find a satisfactory LODES submatrix.")
+
+    row_meta = pd.DataFrame(
+        {
+            "home_county": best["row_labels"],
+            "commuter_total": best["matrix"].sum(axis=1).astype(int),
+        }
+    )
+    col_meta = pd.DataFrame(
+        {
+            "work_county": best["col_labels"],
+            "job_total": best["matrix"].sum(axis=0).astype(int),
+        }
+    )
+    return (
+        best["matrix"],
+        best["row_labels"],
+        best["col_labels"],
+        row_meta,
+        col_meta,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_directories()
+    od_path = download_source(OD_URL, OD_FILENAME, args.refresh)
+    xwalk_path = download_source(XWALK_URL, XWALK_FILENAME, args.refresh)
+
+    matrix_df = load_county_matrix(od_path)
+    county_names = load_county_names(xwalk_path)
+    original_matrix, row_codes, col_codes, row_meta, col_meta = find_best_submatrix(
+        matrix_df
+    )
+    row_labels = np.array(
+        [county_names.get(code, code).replace(", TN", "") for code in row_codes]
+    )
+    col_labels = np.array(
+        [county_names.get(code, code).replace(", TN", "") for code in col_codes]
+    )
+
+    tw_matrix, tw_row_labels = spectral_permute(
+        original_matrix,
+        row_labels,
+        mode="tw",
+    )
+    tw_col_labels = recover_column_labels(
+        original_matrix,
+        row_labels,
+        col_labels,
+        tw_matrix,
+        tw_row_labels,
+    )
+
+    write_matrix_csv_fast(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_original_matrix.csv",
+        original_matrix,
+        row_labels,
+        col_labels,
+    )
+    write_matrix_csv_fast(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_tw_matrix.csv",
+        tw_matrix,
+        tw_row_labels,
+        tw_col_labels,
+    )
+    write_metadata_csv(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_row_metadata.csv",
+        ("home_county_code", "home_county_name", "commuter_total"),
+        [
+            (
+                code,
+                county_names.get(code, code),
+                int(total),
+            )
+            for code, total in zip(
+                row_meta["home_county"],
+                row_meta["commuter_total"],
+                strict=True,
+            )
+        ],
+    )
+    write_metadata_csv(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_col_metadata.csv",
+        ("work_county_code", "work_county_name", "job_total"),
+        [
+            (
+                code,
+                county_names.get(code, code),
+                int(total),
+            )
+            for code, total in zip(
+                col_meta["work_county"],
+                col_meta["job_total"],
+                strict=True,
+            )
+        ],
+    )
+
+    figure_path = FIGURES_DIR / f"{OUTPUT_STEM}_original_vs_tw_vs_tw_mosaic.png"
+    plot_triptych(
+        original_matrix=original_matrix,
+        tw_matrix=tw_matrix,
+        original_row_labels=row_labels,
+        original_col_labels=col_labels,
+        tw_row_labels=tw_row_labels,
+        tw_col_labels=tw_col_labels,
+        output_path=figure_path,
+        figure_title="Tennessee LODES8 2022 Home County to Work County",
+        subtitle=(
+            f"{original_matrix.shape[0]} home counties x "
+            f"{original_matrix.shape[1]} work counties, "
+            "S000 commuter counts"
+        ),
+        colorbar_label="Commuter count (S000)",
+        band_frac=0.18,
+        mask_below=500,
+    )
+
+    if args.show:
+        image = plt.imread(figure_path)
+        plt.figure(figsize=(18, 8))
+        plt.imshow(image)
+        plt.axis("off")
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/naics_sic_rectangular/demo_tw_mosaic.py
+++ b/Examples/naics_sic_rectangular/demo_tw_mosaic.py
@@ -1,0 +1,217 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.request
+from pathlib import Path
+
+sys.modules.setdefault("numexpr", None)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+EXAMPLES_DIR = REPO_ROOT / "Examples"
+for path in (SRC_DIR, EXAMPLES_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import numpy as np
+import pandas as pd
+from mheatmap.graph import spectral_permute
+
+from _rectangular_tw_common import (
+    plot_triptych,
+    recover_column_labels,
+    write_matrix_csv_fast,
+    write_metadata_csv,
+)
+
+RAW_DIR = REPO_ROOT / "data" / "naics_sic_rectangular" / "raw"
+PROCESSED_DIR = REPO_ROOT / "data" / "naics_sic_rectangular" / "processed"
+FIGURES_DIR = REPO_ROOT / "data" / "naics_sic_rectangular" / "figures"
+
+SOURCE_URL = (
+    "https://www2.census.gov/library/reference/naics/technical-documentation/"
+    "concordance/1987_sic_to_2002_naics.xls"
+)
+RAW_XLS_FILENAME = "1987_sic_to_2002_naics.xls"
+RAW_CSV_FILENAME = "1987_sic_to_2002_naics.csv"
+OUTPUT_STEM = "sic1987_to_naics2002"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download the official 1987 SIC -> 2002 NAICS concordance, "
+            "construct the full binary rectangular mapping matrix, and compare "
+            "original / TW / TW+mosaic views."
+        )
+    )
+    parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--show", action="store_true")
+    return parser.parse_args()
+
+
+def ensure_directories() -> None:
+    for directory in (RAW_DIR, PROCESSED_DIR, FIGURES_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def download_source(refresh: bool) -> Path:
+    path = RAW_DIR / RAW_XLS_FILENAME
+    if refresh or not path.exists():
+        path.unlink(missing_ok=True)
+        urllib.request.urlretrieve(SOURCE_URL, path)
+    return path
+
+
+def ensure_csv_source(xls_path: Path, refresh: bool) -> Path:
+    csv_path = RAW_DIR / RAW_CSV_FILENAME
+    if csv_path.exists() and not refresh:
+        return csv_path
+
+    try:
+        df = pd.read_excel(xls_path)
+    except ImportError:
+        if csv_path.exists():
+            return csv_path
+        raise RuntimeError(
+            "This example needs either xlrd to read the downloaded .xls file or an "
+            "already-generated CSV cache at "
+            f"{csv_path}."
+        ) from None
+
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def build_matrix(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray, pd.DataFrame]:
+    df = pd.read_csv(path)
+    df["SIC"] = df["SIC"].astype(str).str.extract(r"(\d+)")[0].str.zfill(4)
+    df["2002 NAICS"] = df["2002 NAICS"].astype(str).str.extract(r"(\d+)")[0]
+    df = df.dropna(subset=["SIC", "2002 NAICS"]).copy()
+    df = df.drop_duplicates(subset=["SIC", "2002 NAICS"])
+
+    sic_title_col = "SIC Title (and note)"
+
+    sic_meta = (
+        df[["SIC", sic_title_col]]
+        .drop_duplicates(subset=["SIC"])
+        .sort_values("SIC")
+        .reset_index(drop=True)
+    )
+    naics_meta = (
+        df[["2002 NAICS", "2002 NAICS Title"]]
+        .drop_duplicates(subset=["2002 NAICS"])
+        .sort_values("2002 NAICS")
+        .reset_index(drop=True)
+    )
+
+    row_labels = sic_meta["SIC"].to_numpy()
+    col_labels = naics_meta["2002 NAICS"].to_numpy()
+    row_lookup = {label: index for index, label in enumerate(row_labels)}
+    col_lookup = {label: index for index, label in enumerate(col_labels)}
+
+    matrix = np.zeros((len(row_labels), len(col_labels)), dtype=float)
+    for sic, naics in df[["SIC", "2002 NAICS"]].itertuples(index=False):
+        matrix[row_lookup[sic], col_lookup[naics]] = 1.0
+
+    return matrix, row_labels, col_labels, df
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_directories()
+    source_path = download_source(args.refresh)
+    csv_path = ensure_csv_source(source_path, args.refresh)
+
+    original_matrix, row_labels, col_labels, mapping_df = build_matrix(csv_path)
+    tw_matrix, tw_row_labels = spectral_permute(
+        original_matrix,
+        row_labels,
+        mode="tw",
+    )
+    tw_col_labels = recover_column_labels(
+        original_matrix,
+        row_labels,
+        col_labels,
+        tw_matrix,
+        tw_row_labels,
+    )
+
+    write_matrix_csv_fast(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_original_matrix.csv",
+        original_matrix,
+        row_labels,
+        col_labels,
+    )
+    write_matrix_csv_fast(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_tw_matrix.csv",
+        tw_matrix,
+        tw_row_labels,
+        tw_col_labels,
+    )
+    write_metadata_csv(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_row_metadata.csv",
+        ("sic", "sic_title"),
+        [
+            (code, title)
+            for code, title in zip(
+                mapping_df[["SIC", "SIC Title (and note)"]]
+                .drop_duplicates(subset=["SIC"])
+                .sort_values("SIC")["SIC"],
+                mapping_df[["SIC", "SIC Title (and note)"]]
+                .drop_duplicates(subset=["SIC"])
+                .sort_values("SIC")["SIC Title (and note)"],
+                strict=True,
+            )
+        ],
+    )
+    write_metadata_csv(
+        PROCESSED_DIR / f"{OUTPUT_STEM}_col_metadata.csv",
+        ("naics_2002", "naics_2002_title"),
+        [
+            (code, title)
+            for code, title in zip(
+                mapping_df[["2002 NAICS", "2002 NAICS Title"]]
+                .drop_duplicates(subset=["2002 NAICS"])
+                .sort_values("2002 NAICS")["2002 NAICS"],
+                mapping_df[["2002 NAICS", "2002 NAICS Title"]]
+                .drop_duplicates(subset=["2002 NAICS"])
+                .sort_values("2002 NAICS")["2002 NAICS Title"],
+                strict=True,
+            )
+        ],
+    )
+
+    figure_path = FIGURES_DIR / f"{OUTPUT_STEM}_original_vs_tw_vs_tw_mosaic.png"
+    plot_triptych(
+        original_matrix=original_matrix,
+        tw_matrix=tw_matrix,
+        original_row_labels=row_labels,
+        original_col_labels=col_labels,
+        tw_row_labels=tw_row_labels,
+        tw_col_labels=tw_col_labels,
+        output_path=figure_path,
+        figure_title="1987 SIC to 2002 NAICS Concordance",
+        subtitle=(
+            f"{original_matrix.shape[0]} SIC rows x "
+            f"{original_matrix.shape[1]} NAICS columns, "
+            f"{int(original_matrix.sum())} official mapping pairs"
+        ),
+        colorbar_label="Binary concordance entry",
+    )
+
+    if args.show:
+        import matplotlib.pyplot as plt
+
+        image = plt.imread(figure_path)
+        plt.figure(figsize=(18, 8))
+        plt.imshow(image)
+        plt.axis("off")
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/rectangular_evaluation/README.md
+++ b/Examples/rectangular_evaluation/README.md
@@ -1,0 +1,76 @@
+# Rectangular Evaluation
+
+This folder contains two evaluation scripts for rectangular / bipartite matrices.
+
+## Real Data
+
+`run_realdata_evaluation.py` compares five methods on the three real-data examples:
+
+- `Original`
+- `Marginal`
+- `HC+OLO`
+- `One-walk`
+- `TW`
+
+Datasets:
+
+- `1987 SIC -> 2002 NAICS`
+- `ACS 2023 Massachusetts PUMS`
+- `Tennessee LODES 2022`
+
+Metrics:
+
+- `2-SUM` (mass-normalized rectangular variant)
+- `Band@5%`, `Band@10%`, `Band@20%`
+- `MWB-AUC`
+- `runtime`
+
+Run:
+
+```bash
+python Examples/rectangular_evaluation/run_realdata_evaluation.py
+```
+
+## Synthetic
+
+`run_synthetic_evaluation.py` builds a hierarchical rectangular synthetic benchmark with:
+
+- `5` super-blocks
+- `3` matrix sizes: `Small`, `Medium`, `Large`
+- `5` synthetic families:
+  - `Family A: Clean one-to-one`
+  - `Family B: Paired subgroup overlap`
+  - `Family C: Shared super-prototype`
+  - `Family D: Shared prototype with noise`
+  - `Family E: Cross-block leakage`
+
+Each family/size regime is evaluated across multiple random seeds with the same five
+methods as above. In addition to `2-SUM`, band-mass, and `MWB-AUC`, the script
+records contiguous-segmentation recovery scores:
+
+- `ARI(sub)` / `NMI(sub)`
+- `ARI(super)` / `NMI(super)`
+
+Run:
+
+```bash
+python Examples/rectangular_evaluation/run_synthetic_evaluation.py
+```
+
+## Synthetic Alpha Sweep
+
+`run_synthetic_alpha_sweep.py` evaluates `TW(alpha)` against `One-walk` on the same
+synthetic family/size grid, without modifying `src/`. The sweep uses:
+
+- `alpha in {2, 4, 6, 8, 12}`
+
+It writes per-seed metrics, aggregated summaries, and a best-alpha comparison for each
+family/size regime.
+
+Run:
+
+```bash
+python Examples/rectangular_evaluation/run_synthetic_alpha_sweep.py
+```
+
+Outputs are written under `data/rectangular_evaluation/`.

--- a/Examples/rectangular_evaluation/_benchmark_utils.py
+++ b/Examples/rectangular_evaluation/_benchmark_utils.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from _rectangular_tw_common import diagonal_band_mass
+from scipy.cluster.hierarchy import leaves_list, linkage, optimal_leaf_ordering
+from scipy.linalg import eigh
+from scipy.spatial.distance import pdist
+from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+
+from mheatmap.graph import (
+    copermute_from_bipermute,
+    spectral_permute,
+    two_walk_laplacian,
+)
+
+
+@dataclass(frozen=True)
+class ReorderResult:
+    matrix: np.ndarray
+    row_order: np.ndarray
+    col_order: np.ndarray
+
+
+def load_matrix_csv(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    with path.open(encoding="utf-8") as handle:
+        rows = list(csv.reader(handle))
+    col_labels = np.array(rows[0][1:])
+    row_labels = np.array([row[0] for row in rows[1:]])
+    matrix = np.array([[float(value) for value in row[1:]] for row in rows[1:]])
+    return matrix, row_labels, col_labels
+
+
+def apply_orders(
+    matrix: np.ndarray,
+    row_order: np.ndarray,
+    col_order: np.ndarray,
+) -> np.ndarray:
+    return matrix[row_order][:, col_order]
+
+
+def recover_column_order(
+    original_matrix: np.ndarray,
+    row_order: np.ndarray,
+    reordered_matrix: np.ndarray,
+) -> np.ndarray:
+    row_reordered_original = original_matrix[row_order, :]
+
+    column_lookup: dict[bytes, list[int]] = {}
+    for col_index in range(row_reordered_original.shape[1]):
+        key = np.ascontiguousarray(row_reordered_original[:, col_index]).tobytes()
+        column_lookup.setdefault(key, []).append(col_index)
+
+    recovered = []
+    for col_index in range(reordered_matrix.shape[1]):
+        key = np.ascontiguousarray(reordered_matrix[:, col_index]).tobytes()
+        matches = column_lookup.get(key)
+        if not matches:
+            raise ValueError("Could not recover reordered column order from matrix.")
+        recovered.append(matches.pop(0))
+    return np.array(recovered, dtype=int)
+
+
+def normalized_two_sum(matrix: np.ndarray) -> float:
+    total = float(np.sum(matrix))
+    if total <= 0:
+        return 0.0
+
+    n_rows, n_cols = matrix.shape
+    row_positions = np.linspace(0.0, 1.0, n_rows)[:, None]
+    if n_cols == 1:
+        col_positions = np.zeros((1, 1))
+    else:
+        col_positions = np.linspace(0.0, 1.0, n_cols)[None, :]
+    squared_distance = (row_positions - col_positions) ** 2
+    return float(np.sum(matrix * squared_distance) / total)
+
+
+def mwb_auc(matrix: np.ndarray, widths: np.ndarray) -> float:
+    scores = np.array([diagonal_band_mass(matrix, width) for width in widths])
+    return float(np.trapezoid(scores, widths) / (widths[-1] - widths[0]))
+
+
+def orient_orders_for_diagonal(
+    matrix: np.ndarray,
+    row_order: np.ndarray,
+    col_order: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    candidates = [
+        (row_order, col_order),
+        (row_order[::-1], col_order),
+        (row_order, col_order[::-1]),
+        (row_order[::-1], col_order[::-1]),
+    ]
+
+    best_score = None
+    best_pair = candidates[0]
+    for candidate_rows, candidate_cols in candidates:
+        candidate_matrix = apply_orders(matrix, candidate_rows, candidate_cols)
+        score = normalized_two_sum(candidate_matrix)
+        if best_score is None or score < best_score:
+            best_score = score
+            best_pair = (candidate_rows, candidate_cols)
+    return best_pair
+
+
+def nonzero_axis_indices(
+    matrix: np.ndarray,
+    axis: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    sums = np.sum(matrix, axis=axis)
+    nonzero = np.where(sums > 0)[0]
+    zero = np.where(sums <= 0)[0]
+    return nonzero, zero
+
+
+def _center_of_mass(values: np.ndarray, axis_length: int) -> np.ndarray:
+    positions = np.arange(axis_length, dtype=float)
+    totals = values.sum(axis=1)
+    weighted = values @ positions
+    return np.divide(
+        weighted,
+        totals,
+        out=np.full(values.shape[0], axis_length, dtype=float),
+        where=totals > 0,
+    )
+
+
+def marginal_sort_reorder(matrix: np.ndarray) -> ReorderResult:
+    row_sums = np.sum(matrix, axis=1)
+    col_sums = np.sum(matrix, axis=0)
+    row_centers = _center_of_mass(matrix, matrix.shape[1])
+    col_centers = _center_of_mass(matrix.T, matrix.shape[0])
+
+    row_order = np.lexsort((row_centers, -row_sums))
+    col_order = np.lexsort((col_centers, -col_sums))
+    row_order, col_order = orient_orders_for_diagonal(matrix, row_order, col_order)
+    return ReorderResult(
+        apply_orders(matrix, row_order, col_order),
+        row_order,
+        col_order,
+    )
+
+
+def _olo_order(vectors: np.ndarray) -> np.ndarray:
+    count = vectors.shape[0]
+    if count <= 1:
+        return np.arange(count, dtype=int)
+    if count == 2:
+        totals = np.sum(vectors, axis=1)
+        return np.argsort(-totals, kind="mergesort")
+
+    distances = pdist(vectors, metric="cosine")
+    if not np.isfinite(distances).all() or np.allclose(distances, 0):
+        totals = np.sum(vectors, axis=1)
+        centers = _center_of_mass(vectors, vectors.shape[1])
+        return np.lexsort((centers, -totals))
+
+    tree = linkage(distances, method="average")
+    ordered_tree = optimal_leaf_ordering(tree, distances)
+    return leaves_list(ordered_tree).astype(int)
+
+
+def hierarchical_olo_reorder(matrix: np.ndarray) -> ReorderResult:
+    row_nonzero, row_zero = nonzero_axis_indices(matrix, axis=1)
+    col_nonzero, col_zero = nonzero_axis_indices(matrix, axis=0)
+
+    if len(row_nonzero) == 0 or len(col_nonzero) == 0:
+        row_order = np.arange(matrix.shape[0], dtype=int)
+        col_order = np.arange(matrix.shape[1], dtype=int)
+        return ReorderResult(matrix.copy(), row_order, col_order)
+
+    row_local = _olo_order(matrix[row_nonzero][:, col_nonzero])
+    col_local = _olo_order(matrix[row_nonzero][:, col_nonzero].T)
+    row_order = np.concatenate([row_nonzero[row_local], row_zero])
+    col_order = np.concatenate([col_nonzero[col_local], col_zero])
+    row_order, col_order = orient_orders_for_diagonal(matrix, row_order, col_order)
+    return ReorderResult(
+        apply_orders(matrix, row_order, col_order),
+        row_order,
+        col_order,
+    )
+
+
+def one_walk_reorder(matrix: np.ndarray) -> ReorderResult:
+    rows, cols = matrix.shape
+    row_sums = np.sum(matrix, axis=1)
+    col_sums = np.sum(matrix, axis=0)
+    nonzero_rows = np.where(row_sums > 0)[0]
+    nonzero_cols = np.where(col_sums > 0)[0]
+
+    if len(nonzero_rows) == 0 or len(nonzero_cols) == 0:
+        row_order = np.arange(rows, dtype=int)
+        col_order = np.arange(cols, dtype=int)
+        return ReorderResult(matrix.copy(), row_order, col_order)
+
+    B_sub = matrix[np.ix_(nonzero_rows, nonzero_cols)].astype(float)
+    if np.max(B_sub) > 0:
+        B_sub = B_sub / np.max(B_sub)
+
+    zeros_rr = np.zeros((B_sub.shape[0], B_sub.shape[0]), dtype=float)
+    zeros_cc = np.zeros((B_sub.shape[1], B_sub.shape[1]), dtype=float)
+    adjacency = np.block([[zeros_rr, B_sub], [B_sub.T, zeros_cc]])
+    degree = np.diag(np.sum(adjacency, axis=1))
+    laplacian = degree - adjacency
+    eigenvalues, eigenvectors = eigh(laplacian)
+    fiedler_index = np.where(np.abs(eigenvalues) > 1e-10)[0][0]
+    bipartite_order = np.argsort(eigenvectors[:, fiedler_index])
+    row_order, col_order = copermute_from_bipermute(
+        [rows, cols],
+        nonzero_rows,
+        nonzero_cols,
+        bipartite_order,
+    )
+    row_order, col_order = orient_orders_for_diagonal(matrix, row_order, col_order)
+    return ReorderResult(
+        apply_orders(matrix, row_order, col_order),
+        row_order,
+        col_order,
+    )
+
+
+def tw_reorder(matrix: np.ndarray) -> ReorderResult:
+    row_labels = np.arange(matrix.shape[0], dtype=int)
+    tw_matrix, tw_row_labels = spectral_permute(matrix, row_labels, mode="tw")
+    row_order = tw_row_labels.astype(int)
+    col_order = recover_column_order(matrix, row_order, tw_matrix)
+    row_order, col_order = orient_orders_for_diagonal(matrix, row_order, col_order)
+    return ReorderResult(
+        apply_orders(matrix, row_order, col_order),
+        row_order,
+        col_order,
+    )
+
+
+def tw_alpha_reorder(matrix: np.ndarray, alpha: float) -> ReorderResult:
+    rows, cols = matrix.shape
+    row_sums = np.sum(matrix, axis=1)
+    col_sums = np.sum(matrix, axis=0)
+    nonzero_rows = np.where(row_sums > 0)[0]
+    nonzero_cols = np.where(col_sums > 0)[0]
+
+    if len(nonzero_rows) == 0 or len(nonzero_cols) == 0:
+        row_order = np.arange(rows, dtype=int)
+        col_order = np.arange(cols, dtype=int)
+        return ReorderResult(matrix.copy(), row_order, col_order)
+
+    B_sub = matrix[np.ix_(nonzero_rows, nonzero_cols)].astype(float)
+    if np.max(B_sub) > 0:
+        B_sub = B_sub / np.max(B_sub)
+
+    laplacian = two_walk_laplacian(B_sub, alpha=alpha)
+    eigenvalues, eigenvectors = eigh(laplacian)
+    fiedler_index = np.where(np.abs(eigenvalues) > 1e-10)[0][0]
+    bipartite_order = np.argsort(eigenvectors[:, fiedler_index])
+    row_order, col_order = copermute_from_bipermute(
+        [rows, cols],
+        nonzero_rows,
+        nonzero_cols,
+        bipartite_order,
+    )
+    row_order, col_order = orient_orders_for_diagonal(matrix, row_order, col_order)
+    return ReorderResult(
+        apply_orders(matrix, row_order, col_order),
+        row_order,
+        col_order,
+    )
+
+
+def compute_curves(
+    method_matrices: dict[str, np.ndarray],
+    widths: np.ndarray,
+) -> dict[str, np.ndarray]:
+    return {
+        method: np.array([diagonal_band_mass(matrix, width) for width in widths])
+        for method, matrix in method_matrices.items()
+    }
+
+
+def _adjacent_cosine_gaps(vectors: np.ndarray) -> np.ndarray:
+    if vectors.shape[0] <= 1:
+        return np.array([], dtype=float)
+
+    left = vectors[:-1].astype(float, copy=False)
+    right = vectors[1:].astype(float, copy=False)
+    left_norm = np.linalg.norm(left, axis=1)
+    right_norm = np.linalg.norm(right, axis=1)
+    denom = left_norm * right_norm
+    dot = np.sum(left * right, axis=1)
+    cosine = np.divide(
+        dot,
+        denom,
+        out=np.zeros_like(dot, dtype=float),
+        where=denom > 0,
+    )
+    both_zero = (left_norm == 0) & (right_norm == 0)
+    cosine[both_zero] = 1.0
+    cosine = np.clip(cosine, -1.0, 1.0)
+    return 1.0 - cosine
+
+
+def contiguous_gap_partition_labels(
+    vectors: np.ndarray,
+    n_clusters: int,
+) -> np.ndarray:
+    n_items = vectors.shape[0]
+    if n_items == 0:
+        return np.array([], dtype=int)
+    if n_clusters <= 1 or n_items == 1:
+        return np.zeros(n_items, dtype=int)
+
+    n_clusters = min(n_clusters, n_items)
+    gaps = _adjacent_cosine_gaps(vectors)
+    if gaps.size < n_clusters - 1 or np.allclose(gaps, gaps[0] if gaps.size else 0.0):
+        boundaries = np.linspace(0, n_items, n_clusters + 1, dtype=int)[1:-1]
+    else:
+        boundaries = np.sort(np.argsort(gaps)[-(n_clusters - 1) :] + 1)
+
+    labels = np.empty(n_items, dtype=int)
+    start = 0
+    for cluster_id, stop in enumerate(np.append(boundaries, n_items)):
+        labels[start:stop] = cluster_id
+        start = stop
+    return labels
+
+
+def contiguous_cluster_scores(
+    reordered_matrix: np.ndarray,
+    true_row_labels: np.ndarray,
+    true_col_labels: np.ndarray,
+) -> dict[str, float]:
+    row_k = int(np.unique(true_row_labels).size)
+    col_k = int(np.unique(true_col_labels).size)
+    pred_row_labels = contiguous_gap_partition_labels(reordered_matrix, row_k)
+    pred_col_labels = contiguous_gap_partition_labels(reordered_matrix.T, col_k)
+
+    ari_row = float(adjusted_rand_score(true_row_labels, pred_row_labels))
+    ari_col = float(adjusted_rand_score(true_col_labels, pred_col_labels))
+    nmi_row = float(normalized_mutual_info_score(true_row_labels, pred_row_labels))
+    nmi_col = float(normalized_mutual_info_score(true_col_labels, pred_col_labels))
+    return {
+        "ari_row": ari_row,
+        "ari_col": ari_col,
+        "ari_mean": 0.5 * (ari_row + ari_col),
+        "nmi_row": nmi_row,
+        "nmi_col": nmi_col,
+        "nmi_mean": 0.5 * (nmi_row + nmi_col),
+    }

--- a/Examples/rectangular_evaluation/make_synthetic_results_table.py
+++ b/Examples/rectangular_evaluation/make_synthetic_results_table.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_DIR = REPO_ROOT / "data" / "rectangular_evaluation" / "processed"
+
+PRIMARY_SORT = ["mwb_auc_mean", "two_sum_mean", "ari_sub_mean", "nmi_sub_mean"]
+METHOD_ORDER = ["Original", "Marginal", "HC+OLO", "One-walk", "TW(best $\\alpha$)"]
+METHOD_SHORT = {
+    "Original": "O",
+    "Marginal": "M",
+    "HC+OLO": "HC",
+    "One-walk": "OW",
+    "TW(best $\\alpha$)": "TW$^{*}$",
+}
+
+
+def load_tables() -> tuple[pd.DataFrame, pd.DataFrame]:
+    summary = pd.read_csv(OUTPUT_DIR / "synthetic_summary.csv")
+    alpha_best = pd.read_csv(OUTPUT_DIR / "synthetic_alpha_best.csv")
+    return summary, alpha_best
+
+
+def choose_best_baseline(summary: pd.DataFrame) -> pd.DataFrame:
+    baselines = summary[
+        summary["method"].isin(["Original", "Marginal", "HC+OLO", "One-walk"])
+    ].copy()
+    baselines = baselines.sort_values(
+        [
+            "family",
+            "size",
+            "mwb_auc_mean",
+            "two_sum_mean",
+            "ari_sub_mean",
+            "nmi_sub_mean",
+        ],
+        ascending=[True, True, False, True, False, False],
+    )
+    best = baselines.groupby(["family", "size"], as_index=False).first()
+    best = best.rename(
+        columns={
+            "method": "baseline_method",
+            "two_sum_mean": "baseline_two_sum",
+            "band_mass_10_mean": "baseline_band10",
+            "mwb_auc_mean": "baseline_auc",
+            "ari_sub_mean": "baseline_ari",
+            "nmi_sub_mean": "baseline_nmi",
+            "runtime_mean": "baseline_runtime",
+        }
+    )
+    return best[
+        [
+            "family",
+            "size",
+            "baseline_method",
+            "baseline_two_sum",
+            "baseline_band10",
+            "baseline_auc",
+            "baseline_ari",
+            "baseline_nmi",
+            "baseline_runtime",
+        ]
+    ]
+
+
+def build_main_table(summary: pd.DataFrame, alpha_best: pd.DataFrame) -> pd.DataFrame:
+    baseline = choose_best_baseline(summary)
+    tw = alpha_best.rename(
+        columns={
+            "alpha": "tw_alpha",
+            "two_sum_mean": "tw_two_sum",
+            "band_mass_10_mean": "tw_band10",
+            "mwb_auc_mean": "tw_auc",
+            "ari_sub_mean": "tw_ari",
+            "nmi_sub_mean": "tw_nmi",
+            "runtime_mean": "tw_runtime",
+        }
+    )
+    merged = baseline.merge(
+        tw[
+            [
+                "family",
+                "size",
+                "tw_alpha",
+                "tw_two_sum",
+                "tw_band10",
+                "tw_auc",
+                "tw_ari",
+                "tw_nmi",
+                "tw_runtime",
+            ]
+        ],
+        on=["family", "size"],
+        how="inner",
+    )
+    merged["tw_beats_baseline_auc"] = merged["tw_auc"] > merged["baseline_auc"]
+    merged["tw_beats_baseline_two_sum"] = (
+        merged["tw_two_sum"] < merged["baseline_two_sum"]
+    )
+    merged["tw_beats_baseline_ari"] = merged["tw_ari"] > merged["baseline_ari"]
+    merged["tw_beats_baseline_nmi"] = merged["tw_nmi"] > merged["baseline_nmi"]
+    size_order = {"Small": 0, "Medium": 1, "Large": 2}
+    merged["size_order"] = merged["size"].map(size_order)
+    merged = merged.sort_values(["family", "size_order"]).drop(columns="size_order")
+    return merged
+
+
+def format_metric_pair(tw: float, base: float, higher_is_better: bool) -> str:
+    tw_fmt = f"{tw:.3f}" if higher_is_better else f"{tw:.4f}"
+    base_fmt = f"{base:.3f}" if higher_is_better else f"{base:.4f}"
+    if (tw > base and higher_is_better) or (tw < base and not higher_is_better):
+        tw_fmt = f"\\textbf{{{tw_fmt}}}"
+    elif (tw < base and higher_is_better) or (tw > base and not higher_is_better):
+        base_fmt = f"\\textbf{{{base_fmt}}}"
+    return tw_fmt, base_fmt
+
+
+def make_latex_table(main_table: pd.DataFrame) -> str:
+    lines = [
+        "\\begin{table*}[t]",
+        "\\centering",
+        "\\small",
+        "\\setlength{\\tabcolsep}{4pt}",
+        "\\begin{tabular}{ll l rr rr rr rr r}",
+        "\\toprule",
+        "& & & \\multicolumn{2}{c}{2-SUM $\\downarrow$} & "
+        "\\multicolumn{2}{c}{MWB-AUC $\\uparrow$} & "
+        "\\multicolumn{2}{c}{ARI $\\uparrow$} & "
+        "\\multicolumn{2}{c}{NMI $\\uparrow$} & "
+        "Best \\\\",
+        "Family & Size & Baseline & Base & TW$^{*}$ & Base & TW$^{*}$ & "
+        "Base & TW$^{*}$ & Base & TW$^{*}$ & $\\alpha$ \\\\",
+        "\\midrule",
+    ]
+
+    family_counts = main_table["family"].value_counts().to_dict()
+    emitted = set()
+    for row in main_table.itertuples(index=False):
+        family_cell = ""
+        if row.family not in emitted:
+            family_label = row.family.replace("Family ", "F")
+            family_cell = (
+                f"\\multirow{{{family_counts[row.family]}}}{{*}}{{{family_label}}}"
+            )
+            emitted.add(row.family)
+        base_two, tw_two = format_metric_pair(
+            row.baseline_two_sum,
+            row.tw_two_sum,
+            False,
+        )
+        base_auc, tw_auc = format_metric_pair(row.baseline_auc, row.tw_auc, True)
+        base_ari, tw_ari = format_metric_pair(row.baseline_ari, row.tw_ari, True)
+        base_nmi, tw_nmi = format_metric_pair(row.baseline_nmi, row.tw_nmi, True)
+        lines.append(
+            f"{family_cell} & {row.size} & {row.baseline_method} & "
+            f"{base_two} & {tw_two} & "
+            f"{base_auc} & {tw_auc} & "
+            f"{base_ari} & {tw_ari} & "
+            f"{base_nmi} & {tw_nmi} & "
+            f"{int(row.tw_alpha)} \\\\"
+        )
+    lines.extend(
+        [
+            "\\bottomrule",
+            "\\end{tabular}",
+            "\\caption{Synthetic rectangular benchmark. Each row reports the "
+            "strongest non-TW baseline (chosen by MWB-AUC, with 2-SUM tie-break) "
+            "against TW with the best $\\alpha \\in \\{2,4,6,8,12\\}$ for that "
+            "family/size regime. ARI and NMI use contiguous subgroup recovery "
+            "from the reordered matrix.}",
+            "\\label{tab:synthetic-rectangular-main}",
+            "\\end{table*}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def make_full_csv(summary: pd.DataFrame, alpha_best: pd.DataFrame) -> pd.DataFrame:
+    tw = alpha_best.copy()
+    tw["method"] = "TW(best $\\alpha$)"
+    tw = tw.rename(
+        columns={
+            "alpha": "best_alpha",
+            "two_sum_mean": "two_sum_mean",
+            "band_mass_10_mean": "band_mass_10_mean",
+            "mwb_auc_mean": "mwb_auc_mean",
+            "ari_sub_mean": "ari_sub_mean",
+            "nmi_sub_mean": "nmi_sub_mean",
+            "runtime_mean": "runtime_mean",
+        }
+    )
+    tw = tw[
+        [
+            "family",
+            "size",
+            "method",
+            "best_alpha",
+            "two_sum_mean",
+            "band_mass_10_mean",
+            "mwb_auc_mean",
+            "ari_sub_mean",
+            "nmi_sub_mean",
+            "runtime_mean",
+        ]
+    ]
+
+    full = summary[
+        [
+            "family",
+            "size",
+            "method",
+            "two_sum_mean",
+            "band_mass_10_mean",
+            "mwb_auc_mean",
+            "ari_sub_mean",
+            "nmi_sub_mean",
+            "runtime_mean",
+        ]
+    ].copy()
+    full["best_alpha"] = pd.NA
+    full = pd.concat([full, tw], ignore_index=True, sort=False)
+    size_order = {"Small": 0, "Medium": 1, "Large": 2}
+    method_order = {
+        "Original": 0,
+        "Marginal": 1,
+        "HC+OLO": 2,
+        "One-walk": 3,
+        "TW": 4,
+        "TW(best $\\alpha$)": 5,
+    }
+    full["size_order"] = full["size"].map(size_order)
+    full["method_order"] = full["method"].map(method_order).fillna(99)
+    return full.sort_values(["family", "size_order", "method_order"]).drop(
+        columns=["size_order", "method_order"]
+    )
+
+
+def abbreviate_family(name: str) -> str:
+    return name.replace("Family ", "F")
+
+
+def build_wide_table(summary: pd.DataFrame, alpha_best: pd.DataFrame) -> pd.DataFrame:
+    full = make_full_csv(summary, alpha_best).copy()
+    value_columns = [
+        "two_sum_mean",
+        "mwb_auc_mean",
+        "runtime_mean",
+        "ari_sub_mean",
+        "nmi_sub_mean",
+    ]
+    wide = (
+        full.pivot_table(
+            index=["family", "size"],
+            columns="method",
+            values=value_columns,
+            aggfunc="first",
+        )
+        .sort_index(axis=1)
+        .reset_index()
+    )
+    wide.columns = [
+        "_".join([str(part) for part in col if str(part) != ""]).strip("_")
+        for col in wide.columns.to_flat_index()
+    ]
+    size_order = {"Small": 0, "Medium": 1, "Large": 2}
+    wide["size_order"] = wide["size"].map(size_order)
+    return wide.sort_values(["family", "size_order"]).drop(columns="size_order")
+
+
+def format_value(value: float, metric: str) -> str:
+    if metric == "runtime_mean":
+        return f"{value:.3f}"
+    if metric == "two_sum_mean":
+        return f"{value:.4f}"
+    return f"{value:.3f}"
+
+
+def maybe_bold(
+    value: float,
+    values: list[float],
+    higher_is_better: bool,
+    metric: str,
+) -> str:
+    target = max(values) if higher_is_better else min(values)
+    formatted = format_value(value, metric)
+    if abs(value - target) <= 1e-12:
+        return f"\\textbf{{{formatted}}}"
+    return formatted
+
+
+def metric_block(
+    row: pd.Series,
+    metric: str,
+    higher_is_better: bool,
+) -> list[str]:
+    values = [row[f"{metric}_{method}"] for method in METHOD_ORDER]
+    return [
+        maybe_bold(row[f"{metric}_{method}"], values, higher_is_better, metric)
+        for method in METHOD_ORDER
+    ]
+
+
+def make_quality_latex_table(wide: pd.DataFrame, alpha_best: pd.DataFrame) -> str:
+    alpha_lookup = {
+        (row.family, row.size): int(row.alpha)
+        for row in alpha_best.itertuples(index=False)
+    }
+    lines = [
+        "\\begin{table*}[t]",
+        "\\centering",
+        "\\scriptsize",
+        "\\setlength{\\tabcolsep}{3pt}",
+        "\\resizebox{\\textwidth}{!}{%",
+        "\\begin{tabular}{ll " + "r" * 16 + "}",
+        "\\toprule",
+        "& & \\multicolumn{5}{c}{2-SUM $\\downarrow$} & "
+        "\\multicolumn{5}{c}{MWB-AUC $\\uparrow$} & "
+        "\\multicolumn{5}{c}{Runtime (s) $\\downarrow$} & Best \\\\",
+        "Family & Size & O & M & HC & OW & TW$^{*}$ & "
+        "O & M & HC & OW & TW$^{*}$ & "
+        "O & M & HC & OW & TW$^{*}$ & $\\alpha$ \\\\",
+        "\\midrule",
+    ]
+    family_counts = wide["family"].value_counts().to_dict()
+    emitted = set()
+    for _, row in wide.iterrows():
+        family = row["family"]
+        size = row["size"]
+        family_cell = ""
+        if family not in emitted:
+            family_cell = (
+                f"\\multirow{{{family_counts[family]}}}{{*}}{{{abbreviate_family(family)}}}"
+            )
+            emitted.add(family)
+        two_block = metric_block(row, "two_sum_mean", False)
+        auc_block = metric_block(row, "mwb_auc_mean", True)
+        run_block = metric_block(row, "runtime_mean", False)
+        alpha = alpha_lookup[(family, size)]
+        lines.append(
+            f"{family_cell} & {size} & "
+            + " & ".join(two_block + auc_block + run_block)
+            + f" & {alpha} \\\\"
+        )
+    lines.extend(
+        [
+            "\\bottomrule",
+            "\\end{tabular}%",
+            "}",
+            "\\caption{Synthetic rectangular benchmark: ordering quality and "
+            "runtime. Methods are Original (O), Marginal (M), HC+OLO (HC), "
+            "One-walk (OW), and TW with the best "
+            "$\\alpha \\in \\{2,4,6,8,12\\}$ for each regime. Bold numbers "
+            "indicate the best method within each row/metric block.}",
+            "\\label{tab:synthetic-rectangular-quality}",
+            "\\end{table*}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def make_recovery_latex_table(wide: pd.DataFrame, alpha_best: pd.DataFrame) -> str:
+    alpha_lookup = {
+        (row.family, row.size): int(row.alpha)
+        for row in alpha_best.itertuples(index=False)
+    }
+    lines = [
+        "\\begin{table*}[t]",
+        "\\centering",
+        "\\scriptsize",
+        "\\setlength{\\tabcolsep}{3pt}",
+        "\\resizebox{\\textwidth}{!}{%",
+        "\\begin{tabular}{ll " + "r" * 11 + "}",
+        "\\toprule",
+        "& & \\multicolumn{5}{c}{ARI $\\uparrow$} & "
+        "\\multicolumn{5}{c}{NMI $\\uparrow$} & Best \\\\",
+        "Family & Size & O & M & HC & OW & TW$^{*}$ & "
+        "O & M & HC & OW & TW$^{*}$ & $\\alpha$ \\\\",
+        "\\midrule",
+    ]
+    family_counts = wide["family"].value_counts().to_dict()
+    emitted = set()
+    for _, row in wide.iterrows():
+        family = row["family"]
+        size = row["size"]
+        family_cell = ""
+        if family not in emitted:
+            family_cell = (
+                f"\\multirow{{{family_counts[family]}}}{{*}}{{{abbreviate_family(family)}}}"
+            )
+            emitted.add(family)
+        ari_block = metric_block(row, "ari_sub_mean", True)
+        nmi_block = metric_block(row, "nmi_sub_mean", True)
+        alpha = alpha_lookup[(family, size)]
+        lines.append(
+            f"{family_cell} & {size} & "
+            + " & ".join(ari_block + nmi_block)
+            + f" & {alpha} \\\\"
+        )
+    lines.extend(
+        [
+            "\\bottomrule",
+            "\\end{tabular}%",
+            "}",
+            "\\caption{Synthetic rectangular benchmark: subgroup recovery "
+            "metrics. ARI and NMI are computed from contiguous subgroup "
+            "partitions induced by the reordered matrix. Methods are "
+            "Original (O), Marginal (M), HC+OLO (HC), One-walk (OW), and TW "
+            "with the best $\\alpha \\in \\{2,4,6,8,12\\}$. Bold numbers "
+            "indicate the best method within each row/metric block.}",
+            "\\label{tab:synthetic-rectangular-recovery}",
+            "\\end{table*}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    summary, alpha_best = load_tables()
+    main_table = build_main_table(summary, alpha_best)
+    main_table.to_csv(OUTPUT_DIR / "synthetic_results_main_table.csv", index=False)
+
+    full_table = make_full_csv(summary, alpha_best)
+    full_table.to_csv(OUTPUT_DIR / "synthetic_results_full_table.csv", index=False)
+
+    wide = build_wide_table(summary, alpha_best)
+    wide.to_csv(OUTPUT_DIR / "synthetic_results_wide_table.csv", index=False)
+
+    latex = make_latex_table(main_table)
+    (OUTPUT_DIR / "synthetic_results_main_table.tex").write_text(
+        latex,
+        encoding="utf-8",
+    )
+    quality_latex = make_quality_latex_table(wide, alpha_best)
+    (OUTPUT_DIR / "synthetic_results_quality_table.tex").write_text(
+        quality_latex,
+        encoding="utf-8",
+    )
+    recovery_latex = make_recovery_latex_table(wide, alpha_best)
+    (OUTPUT_DIR / "synthetic_results_recovery_table.tex").write_text(
+        recovery_latex,
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/rectangular_evaluation/run_realdata_evaluation.py
+++ b/Examples/rectangular_evaluation/run_realdata_evaluation.py
@@ -1,0 +1,229 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.modules.setdefault("numexpr", None)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+EXAMPLES_DIR = REPO_ROOT / "Examples"
+EVAL_DIR = Path(__file__).resolve().parent
+for path in (SRC_DIR, EXAMPLES_DIR, EVAL_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.colors import LogNorm
+
+from _benchmark_utils import (
+    compute_curves,
+    hierarchical_olo_reorder,
+    load_matrix_csv,
+    marginal_sort_reorder,
+    mwb_auc,
+    normalized_two_sum,
+    one_walk_reorder,
+    tw_reorder,
+)
+from _rectangular_tw_common import diagonal_band_mass
+
+OUTPUT_DIR = REPO_ROOT / "data" / "rectangular_evaluation"
+FIGURES_DIR = OUTPUT_DIR / "figures"
+PROCESSED_DIR = OUTPUT_DIR / "processed"
+
+METHOD_ORDER = (
+    "Original",
+    "Marginal",
+    "HC+OLO",
+    "One-walk",
+    "TW",
+)
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    key: str
+    name: str
+    original_csv: Path
+
+
+DATASETS = [
+    DatasetSpec(
+        key="naics_sic",
+        name="1987 SIC -> 2002 NAICS",
+        original_csv=REPO_ROOT
+        / "data"
+        / "naics_sic_rectangular"
+        / "processed"
+        / "sic1987_to_naics2002_original_matrix.csv",
+    ),
+    DatasetSpec(
+        key="acs_pums",
+        name="ACS 2023 MA PUMS OCCP x INDP",
+        original_csv=REPO_ROOT
+        / "data"
+        / "acs_pums_rectangular"
+        / "processed"
+        / "acs2023_ma_occp_indp_original_matrix.csv",
+    ),
+    DatasetSpec(
+        key="lodes",
+        name="TN LODES 2022 Home x Work County",
+        original_csv=REPO_ROOT
+        / "data"
+        / "lodes_rectangular"
+        / "processed"
+        / "tn_lodes2022_home_county_to_work_county_original_matrix.csv",
+    ),
+]
+
+
+def ensure_directories() -> None:
+    for directory in (OUTPUT_DIR, FIGURES_DIR, PROCESSED_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def save_metrics_table(records: list[dict[str, object]]) -> None:
+    df = pd.DataFrame.from_records(records)
+    df.to_csv(PROCESSED_DIR / "realdata_metrics.csv", index=False)
+
+    lines = [
+        "# Real-Data Rectangular Reordering Evaluation",
+        "",
+        (
+            "| Dataset | Method | Shape | 2-SUM | Band@5% | Band@10% | "
+            "Band@20% | MWB-AUC | Runtime (s) |"
+        ),
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in df.itertuples(index=False):
+        lines.append(
+            f"| {row.dataset} | {row.method} | {row.shape} | "
+            f"{row.two_sum:.6f} | {row.band_mass_05:.3f} | {row.band_mass_10:.3f} | "
+            f"{row.band_mass_20:.3f} | {row.mwb_auc:.3f} | {row.runtime_s:.3f} |"
+        )
+    (PROCESSED_DIR / "realdata_metrics.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def plot_mwb_curves(
+    width_grid: np.ndarray,
+    curve_store: dict[str, dict[str, np.ndarray]],
+) -> None:
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), constrained_layout=True)
+    for ax, spec in zip(axes, DATASETS, strict=True):
+        curves = curve_store[spec.key]
+        for method in METHOD_ORDER:
+            ax.plot(width_grid, curves[method], label=method, linewidth=2)
+        ax.set_title(spec.name, fontsize=11)
+        ax.set_xlabel("Band width fraction")
+        ax.set_ylabel("Mass within band")
+        ax.set_ylim(0, 1.02)
+        ax.grid(alpha=0.3)
+    axes[-1].legend(loc="lower right", fontsize=9)
+    fig.savefig(FIGURES_DIR / "realdata_mwb_curves.png", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_heatmap_grid(
+    method_store: dict[str, dict[str, np.ndarray]],
+) -> None:
+    fig, axes = plt.subplots(
+        3,
+        len(METHOD_ORDER),
+        figsize=(24, 12),
+        constrained_layout=True,
+    )
+    for row_index, spec in enumerate(DATASETS):
+        matrices = method_store[spec.key]
+        positive = np.concatenate(
+            [matrix[matrix > 0] for matrix in matrices.values() if np.any(matrix > 0)]
+        )
+        norm = LogNorm(vmin=float(np.min(positive)), vmax=float(np.max(positive)))
+        for col_index, method in enumerate(METHOD_ORDER):
+            ax = axes[row_index, col_index]
+            matrix = np.ma.masked_where(matrices[method] <= 0, matrices[method])
+            image = ax.imshow(
+                matrix,
+                aspect="auto",
+                interpolation="nearest",
+                cmap="YlGnBu",
+                norm=norm,
+            )
+            if row_index == 0:
+                ax.set_title(method, fontsize=14)
+            if col_index == 0:
+                ax.set_ylabel(spec.name, fontsize=11)
+            ax.set_xticks([])
+            ax.set_yticks([])
+            fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+    fig.savefig(
+        FIGURES_DIR / "realdata_method_heatmaps.png",
+        dpi=300,
+        bbox_inches="tight",
+    )
+    plt.close(fig)
+
+
+def main() -> None:
+    ensure_directories()
+    width_grid = np.linspace(0.02, 0.50, 25)
+
+    records: list[dict[str, object]] = []
+    curve_store: dict[str, dict[str, np.ndarray]] = {}
+    method_store: dict[str, dict[str, np.ndarray]] = {}
+
+    reorderers = {
+        "Marginal": marginal_sort_reorder,
+        "HC+OLO": hierarchical_olo_reorder,
+        "One-walk": one_walk_reorder,
+        "TW": tw_reorder,
+    }
+
+    for spec in DATASETS:
+        original_matrix, _, _ = load_matrix_csv(spec.original_csv)
+
+        matrices = {"Original": original_matrix}
+        runtimes = {"Original": 0.0}
+
+        for method, reorder in reorderers.items():
+            start = time.perf_counter()
+            result = reorder(original_matrix)
+            runtimes[method] = time.perf_counter() - start
+            matrices[method] = result.matrix
+
+        curve_store[spec.key] = compute_curves(matrices, width_grid)
+        method_store[spec.key] = matrices
+
+        for method in METHOD_ORDER:
+            matrix = matrices[method]
+            records.append(
+                {
+                    "dataset": spec.name,
+                    "method": method,
+                    "shape": f"{matrix.shape[0]}x{matrix.shape[1]}",
+                    "two_sum": normalized_two_sum(matrix),
+                    "band_mass_05": diagonal_band_mass(matrix, 0.05),
+                    "band_mass_10": diagonal_band_mass(matrix, 0.10),
+                    "band_mass_20": diagonal_band_mass(matrix, 0.20),
+                    "mwb_auc": mwb_auc(matrix, width_grid),
+                    "runtime_s": runtimes[method],
+                }
+            )
+
+    save_metrics_table(records)
+    plot_mwb_curves(width_grid, curve_store)
+    plot_heatmap_grid(method_store)
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/rectangular_evaluation/run_synthetic_alpha_sweep.py
+++ b/Examples/rectangular_evaluation/run_synthetic_alpha_sweep.py
@@ -1,0 +1,290 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.modules.setdefault("numexpr", None)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+EXAMPLES_DIR = REPO_ROOT / "Examples"
+EVAL_DIR = Path(__file__).resolve().parent
+for path in (SRC_DIR, EXAMPLES_DIR, EVAL_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from _benchmark_utils import (
+    contiguous_cluster_scores,
+    mwb_auc,
+    normalized_two_sum,
+    one_walk_reorder,
+    tw_alpha_reorder,
+)
+from _rectangular_tw_common import diagonal_band_mass
+from run_synthetic_evaluation import FAMILIES, NUM_SEEDS, SIZES, WIDTH_GRID, build_case
+
+OUTPUT_DIR = REPO_ROOT / "data" / "rectangular_evaluation"
+FIGURES_DIR = OUTPUT_DIR / "figures"
+PROCESSED_DIR = OUTPUT_DIR / "processed"
+ALPHAS = (2.0, 4.0, 6.0, 8.0, 12.0)
+
+
+def ensure_directories() -> None:
+    for directory in (OUTPUT_DIR, FIGURES_DIR, PROCESSED_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def save_tables(records: list[dict[str, object]]) -> pd.DataFrame:
+    df = pd.DataFrame.from_records(records)
+    df.to_csv(PROCESSED_DIR / "synthetic_alpha_sweep.csv", index=False)
+
+    summary = (
+        df.groupby(
+            ["family", "family_key", "size", "size_key", "method", "alpha"],
+            dropna=False,
+            as_index=False,
+        )
+        .agg(
+            two_sum_mean=("two_sum", "mean"),
+            band_mass_10_mean=("band_mass_10", "mean"),
+            mwb_auc_mean=("mwb_auc", "mean"),
+            ari_sub_mean=("ari_sub_mean", "mean"),
+            nmi_sub_mean=("nmi_sub_mean", "mean"),
+            ari_super_mean=("ari_super_mean", "mean"),
+            nmi_super_mean=("nmi_super_mean", "mean"),
+            runtime_mean=("runtime_s", "mean"),
+        )
+    )
+    summary.to_csv(PROCESSED_DIR / "synthetic_alpha_summary.csv", index=False)
+
+    tw_rows = summary[summary["method"] == "TW(alpha)"].copy()
+    best_auc = (
+        tw_rows.sort_values(
+            ["family", "size", "mwb_auc_mean"],
+            ascending=[True, True, False],
+        )
+        .groupby(["family", "size"], as_index=False)
+        .first()
+    )
+    one_walk = (
+        summary[summary["method"] == "One-walk"]
+        .groupby(["family", "size"], as_index=False)
+        .agg(
+            one_walk_two_sum=("two_sum_mean", "first"),
+            one_walk_band_10=("band_mass_10_mean", "first"),
+            one_walk_mwb_auc=("mwb_auc_mean", "first"),
+            one_walk_ari_sub=("ari_sub_mean", "first"),
+            one_walk_nmi_sub=("nmi_sub_mean", "first"),
+            one_walk_ari_super=("ari_super_mean", "first"),
+            one_walk_nmi_super=("nmi_super_mean", "first"),
+        )
+    )
+    best_auc = best_auc.merge(one_walk, on=["family", "size"], how="left")
+    best_auc["beats_one_walk_auc"] = (
+        best_auc["mwb_auc_mean"] > best_auc["one_walk_mwb_auc"]
+    )
+    best_auc["beats_one_walk_two_sum"] = (
+        best_auc["two_sum_mean"] < best_auc["one_walk_two_sum"]
+    )
+    best_auc["beats_one_walk_ari_sub"] = (
+        best_auc["ari_sub_mean"] > best_auc["one_walk_ari_sub"]
+    )
+    best_auc["beats_one_walk_nmi_sub"] = (
+        best_auc["nmi_sub_mean"] > best_auc["one_walk_nmi_sub"]
+    )
+    best_auc.to_csv(PROCESSED_DIR / "synthetic_alpha_best.csv", index=False)
+
+    family_best = (
+        best_auc.groupby(["family"], as_index=False)
+        .agg(
+            best_alpha_mean=("alpha", "mean"),
+            tw_auc_mean=("mwb_auc_mean", "mean"),
+            ow_auc_mean=("one_walk_mwb_auc", "mean"),
+            tw_two_sum_mean=("two_sum_mean", "mean"),
+            ow_two_sum_mean=("one_walk_two_sum", "mean"),
+            tw_ari_sub_mean=("ari_sub_mean", "mean"),
+            ow_ari_sub_mean=("one_walk_ari_sub", "mean"),
+            tw_nmi_sub_mean=("nmi_sub_mean", "mean"),
+            ow_nmi_sub_mean=("one_walk_nmi_sub", "mean"),
+        )
+    )
+    family_best.to_csv(PROCESSED_DIR / "synthetic_alpha_family_best.csv", index=False)
+
+    lines = [
+        "# Synthetic TW(alpha) Sweep Summary",
+        "",
+        (
+            "| Family | Size | Best alpha | Best TW 2-SUM | Best TW Band@10% | "
+            "Best TW MWB-AUC | Best TW ARI(sub) | Best TW NMI(sub) | "
+            "One-walk 2-SUM | One-walk Band@10% | One-walk MWB-AUC | "
+            "One-walk ARI(sub) | One-walk NMI(sub) | TW beats OW on AUC? | "
+            "TW beats OW on 2-SUM? |"
+        ),
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in best_auc.sort_values(["family", "size"]).itertuples(index=False):
+        lines.append(
+            f"| {row.family} | {row.size} | {row.alpha:.0f} | {row.two_sum_mean:.6f} | "
+            f"{row.band_mass_10_mean:.3f} | {row.mwb_auc_mean:.3f} | "
+            f"{row.ari_sub_mean:.3f} | {row.nmi_sub_mean:.3f} | "
+            f"{row.one_walk_two_sum:.6f} | {row.one_walk_band_10:.3f} | "
+            f"{row.one_walk_mwb_auc:.3f} | {row.one_walk_ari_sub:.3f} | "
+            f"{row.one_walk_nmi_sub:.3f} | {bool(row.beats_one_walk_auc)} | "
+            f"{bool(row.beats_one_walk_two_sum)} |"
+        )
+    (PROCESSED_DIR / "synthetic_alpha_best.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def plot_alpha_curves(summary: pd.DataFrame) -> None:
+    fig, axes = plt.subplots(
+        len(SIZES),
+        len(FAMILIES),
+        figsize=(20, 10),
+        constrained_layout=True,
+    )
+    for row_index, size in enumerate(SIZES):
+        for col_index, family in enumerate(FAMILIES):
+            ax = axes[row_index, col_index]
+            family_tw = summary[
+                (summary["family"] == family.name)
+                & (summary["size"] == size.name)
+                & (summary["method"] == "TW(alpha)")
+            ].sort_values("alpha")
+            one_walk = summary[
+                (summary["family"] == family.name)
+                & (summary["size"] == size.name)
+                & (summary["method"] == "One-walk")
+            ].iloc[0]
+
+            ax.plot(
+                family_tw["alpha"],
+                family_tw["mwb_auc_mean"],
+                marker="o",
+                linewidth=2,
+                label="TW(alpha)",
+            )
+            ax.axhline(
+                one_walk["mwb_auc_mean"],
+                color="black",
+                linestyle="--",
+                linewidth=1.5,
+                label="One-walk",
+            )
+            if row_index == 0:
+                ax.set_title(family.name, fontsize=11)
+            if col_index == 0:
+                ax.set_ylabel(f"{size.name}\nMWB-AUC", fontsize=10)
+            if row_index == len(SIZES) - 1:
+                ax.set_xlabel("alpha")
+            ax.set_xticks(ALPHAS)
+            ax.grid(alpha=0.3)
+    axes[0, -1].legend(loc="lower right", fontsize=8)
+    fig.savefig(
+        FIGURES_DIR / "synthetic_alpha_sweep_mwb_auc.png",
+        dpi=300,
+        bbox_inches="tight",
+    )
+    plt.close(fig)
+
+
+def main() -> None:
+    ensure_directories()
+    records: list[dict[str, object]] = []
+
+    for family in FAMILIES:
+        for size in SIZES:
+            for seed in range(NUM_SEEDS):
+                payload = build_case(family, size, seed)
+                observed = payload["observed"]
+                observed_row_sub = payload["row_sub_labels"][payload["row_perm"]]
+                observed_col_sub = payload["col_sub_labels"][payload["col_perm"]]
+                observed_row_super = payload["row_super_labels"][payload["row_perm"]]
+                observed_col_super = payload["col_super_labels"][payload["col_perm"]]
+
+                start = time.perf_counter()
+                one_walk_result = one_walk_reorder(observed)
+                one_walk_time = time.perf_counter() - start
+                one_walk_sub = contiguous_cluster_scores(
+                    one_walk_result.matrix,
+                    observed_row_sub[one_walk_result.row_order],
+                    observed_col_sub[one_walk_result.col_order],
+                )
+                one_walk_super = contiguous_cluster_scores(
+                    one_walk_result.matrix,
+                    observed_row_super[one_walk_result.row_order],
+                    observed_col_super[one_walk_result.col_order],
+                )
+                records.append(
+                    {
+                        "family": family.name,
+                        "family_key": family.key,
+                        "size": size.name,
+                        "size_key": size.key,
+                        "seed": seed,
+                        "method": "One-walk",
+                        "alpha": np.nan,
+                        "two_sum": normalized_two_sum(one_walk_result.matrix),
+                        "band_mass_10": diagonal_band_mass(
+                            one_walk_result.matrix,
+                            0.10,
+                        ),
+                        "mwb_auc": mwb_auc(one_walk_result.matrix, WIDTH_GRID),
+                        "ari_sub_mean": one_walk_sub["ari_mean"],
+                        "nmi_sub_mean": one_walk_sub["nmi_mean"],
+                        "ari_super_mean": one_walk_super["ari_mean"],
+                        "nmi_super_mean": one_walk_super["nmi_mean"],
+                        "runtime_s": one_walk_time,
+                    }
+                )
+
+                for alpha in ALPHAS:
+                    start = time.perf_counter()
+                    tw_result = tw_alpha_reorder(observed, alpha=alpha)
+                    runtime = time.perf_counter() - start
+                    tw_sub = contiguous_cluster_scores(
+                        tw_result.matrix,
+                        observed_row_sub[tw_result.row_order],
+                        observed_col_sub[tw_result.col_order],
+                    )
+                    tw_super = contiguous_cluster_scores(
+                        tw_result.matrix,
+                        observed_row_super[tw_result.row_order],
+                        observed_col_super[tw_result.col_order],
+                    )
+                    records.append(
+                        {
+                            "family": family.name,
+                            "family_key": family.key,
+                            "size": size.name,
+                            "size_key": size.key,
+                            "seed": seed,
+                            "method": "TW(alpha)",
+                            "alpha": alpha,
+                            "two_sum": normalized_two_sum(tw_result.matrix),
+                            "band_mass_10": diagonal_band_mass(tw_result.matrix, 0.10),
+                            "mwb_auc": mwb_auc(tw_result.matrix, WIDTH_GRID),
+                            "ari_sub_mean": tw_sub["ari_mean"],
+                            "nmi_sub_mean": tw_sub["nmi_mean"],
+                            "ari_super_mean": tw_super["ari_mean"],
+                            "nmi_super_mean": tw_super["nmi_mean"],
+                            "runtime_s": runtime,
+                        }
+                    )
+
+    summary = save_tables(records)
+    plot_alpha_curves(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/rectangular_evaluation/run_synthetic_evaluation.py
+++ b/Examples/rectangular_evaluation/run_synthetic_evaluation.py
@@ -1,0 +1,774 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+sys.modules.setdefault("numexpr", None)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+EXAMPLES_DIR = REPO_ROOT / "Examples"
+EVAL_DIR = Path(__file__).resolve().parent
+for path in (SRC_DIR, EXAMPLES_DIR, EVAL_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.colors import LogNorm
+
+from _benchmark_utils import (
+    ReorderResult,
+    compute_curves,
+    contiguous_cluster_scores,
+    hierarchical_olo_reorder,
+    marginal_sort_reorder,
+    mwb_auc,
+    normalized_two_sum,
+    one_walk_reorder,
+    tw_reorder,
+)
+from _rectangular_tw_common import diagonal_band_mass
+from mheatmap import mosaic_heatmap
+
+OUTPUT_DIR = REPO_ROOT / "data" / "rectangular_evaluation"
+FIGURES_DIR = OUTPUT_DIR / "figures"
+PROCESSED_DIR = OUTPUT_DIR / "processed"
+CASE_DIR = OUTPUT_DIR / "synthetic_cases"
+
+METHOD_ORDER = ("Original", "Marginal", "HC+OLO", "One-walk", "TW")
+SUPER_BLOCKS = 5
+ROW_SUBGROUPS_PER_SUPER = 2
+WIDTH_GRID = np.linspace(0.02, 0.50, 25)
+NUM_SEEDS = 5
+
+
+@dataclass(frozen=True)
+class SizeSpec:
+    key: str
+    name: str
+    n_rows: int
+    n_cols: int
+    row_sub_min: int
+    col_sub_min: int
+
+
+@dataclass(frozen=True)
+class FamilySpec:
+    key: str
+    name: str
+    description: str
+    generator: str
+    col_subgroups_per_super: int
+    unique_keep: float
+    unique_prob: float
+    unique_lambda: float
+    paired_keep: float = 0.0
+    paired_prob: float = 0.0
+    paired_lambda: float = 0.0
+    shared_keep: float = 0.0
+    shared_prob: float = 0.0
+    shared_lambda: float = 0.0
+    cross_keep: float = 0.0
+    cross_prob: float = 0.0
+    cross_lambda: float = 0.0
+    off_target_choices: tuple[int, int] = (0, 0)
+    off_target_lambda: float = 1.0
+
+
+SIZES = (
+    SizeSpec("small", "Small", n_rows=100, n_cols=90, row_sub_min=8, col_sub_min=5),
+    SizeSpec(
+        "medium",
+        "Medium",
+        n_rows=200,
+        n_cols=180,
+        row_sub_min=12,
+        col_sub_min=8,
+    ),
+    SizeSpec(
+        "large",
+        "Large",
+        n_rows=400,
+        n_cols=360,
+        row_sub_min=20,
+        col_sub_min=14,
+    ),
+)
+
+FAMILIES = (
+    FamilySpec(
+        key="clean_block",
+        name="Family A: Clean one-to-one",
+        description=(
+            "Control regime with subgroup-specific columns and negligible leakage."
+        ),
+        generator="clean",
+        col_subgroups_per_super=2,
+        unique_keep=0.82,
+        unique_prob=0.72,
+        unique_lambda=5.0,
+        off_target_choices=(0, 1),
+        off_target_lambda=1.0,
+    ),
+    FamilySpec(
+        key="paired_overlap",
+        name="Family B: Paired subgroup overlap",
+        description=(
+            "Rows mix a primary subgroup prototype with the paired subgroup "
+            "inside the same super-block."
+        ),
+        generator="paired",
+        col_subgroups_per_super=2,
+        unique_keep=0.78,
+        unique_prob=0.60,
+        unique_lambda=4.8,
+        paired_keep=0.72,
+        paired_prob=0.34,
+        paired_lambda=3.0,
+        off_target_choices=(0, 1),
+        off_target_lambda=1.0,
+    ),
+    FamilySpec(
+        key="shared_super",
+        name="Family C: Shared super-prototype",
+        description=(
+            "Each row subgroup combines a unique prototype with a super-block "
+            "prototype shared by both row subgroups."
+        ),
+        generator="shared",
+        col_subgroups_per_super=3,
+        unique_keep=0.74,
+        unique_prob=0.54,
+        unique_lambda=4.4,
+        shared_keep=0.78,
+        shared_prob=0.42,
+        shared_lambda=4.0,
+        off_target_choices=(0, 1),
+        off_target_lambda=1.0,
+    ),
+    FamilySpec(
+        key="shared_super_noisy",
+        name="Family D: Shared prototype with noise",
+        description=(
+            "Shared super-block prototype plus row-specific off-target leakage."
+        ),
+        generator="shared_noisy",
+        col_subgroups_per_super=3,
+        unique_keep=0.72,
+        unique_prob=0.40,
+        unique_lambda=4.2,
+        paired_keep=0.60,
+        paired_prob=0.0,
+        paired_lambda=2.0,
+        shared_keep=0.78,
+        shared_prob=0.48,
+        shared_lambda=4.8,
+        off_target_choices=(0, 1),
+        off_target_lambda=1.0,
+    ),
+    FamilySpec(
+        key="cross_block_leakage",
+        name="Family E: Cross-block leakage",
+        description=(
+            "Shared super-block prototype with occasional weak connections to "
+            "the next super-block."
+        ),
+        generator="cross",
+        col_subgroups_per_super=3,
+        unique_keep=0.72,
+        unique_prob=0.48,
+        unique_lambda=4.0,
+        shared_keep=0.74,
+        shared_prob=0.40,
+        shared_lambda=4.0,
+        cross_keep=0.68,
+        cross_prob=0.12,
+        cross_lambda=2.2,
+        off_target_choices=(0, 1),
+        off_target_lambda=1.1,
+    ),
+)
+
+
+def ensure_directories() -> None:
+    for directory in (OUTPUT_DIR, FIGURES_DIR, PROCESSED_DIR, CASE_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def split_sizes(
+    total: int,
+    n_groups: int,
+    minimum: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    base = np.full(n_groups, minimum, dtype=int)
+    remaining = total - int(base.sum())
+    if remaining < 0:
+        msg = f"Invalid group-size configuration: total={total}, minimum={minimum}"
+        raise ValueError(msg)
+    if remaining == 0:
+        return base
+    allocation = rng.multinomial(remaining, np.full(n_groups, 1.0 / n_groups))
+    return base + allocation
+
+
+def subgroup_intervals(sizes: np.ndarray) -> list[tuple[int, int]]:
+    starts = np.concatenate([[0], np.cumsum(sizes[:-1])])
+    return [
+        (int(start), int(start + size))
+        for start, size in zip(starts, sizes, strict=True)
+    ]
+
+
+def choose_prototype(
+    cols: np.ndarray,
+    keep_fraction: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    if len(cols) == 0:
+        return np.array([], dtype=int)
+    size = min(len(cols), max(2, int(np.ceil(keep_fraction * len(cols)))))
+    return np.sort(rng.choice(cols, size=size, replace=False))
+
+
+def add_weighted_hits(
+    matrix: np.ndarray,
+    row_index: int,
+    cols: np.ndarray,
+    hit_probability: float,
+    poisson_lambda: float,
+    rng: np.random.Generator,
+) -> None:
+    if len(cols) == 0 or hit_probability <= 0:
+        return
+    mask = rng.random(len(cols)) < hit_probability
+    selected = cols[mask]
+    if len(selected) == 0:
+        return
+    matrix[row_index, selected] += 1 + rng.poisson(poisson_lambda, len(selected))
+
+
+def build_case(
+    family: FamilySpec,
+    size: SizeSpec,
+    seed: int,
+) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+
+    row_super_sizes = split_sizes(
+        size.n_rows,
+        SUPER_BLOCKS,
+        ROW_SUBGROUPS_PER_SUPER * size.row_sub_min,
+        rng,
+    )
+    col_super_sizes = split_sizes(
+        size.n_cols,
+        SUPER_BLOCKS,
+        family.col_subgroups_per_super * size.col_sub_min,
+        rng,
+    )
+
+    row_sub_sizes: list[int] = []
+    row_super_labels: list[int] = []
+    row_sub_labels: list[int] = []
+    for super_id, super_size in enumerate(row_super_sizes):
+        sizes = split_sizes(
+            int(super_size),
+            ROW_SUBGROUPS_PER_SUPER,
+            size.row_sub_min,
+            rng,
+        )
+        for local_sub, subgroup_size in enumerate(sizes):
+            row_sub_sizes.append(int(subgroup_size))
+            row_super_labels.extend([super_id] * int(subgroup_size))
+            row_sub_labels.extend(
+                [super_id * ROW_SUBGROUPS_PER_SUPER + local_sub] * int(subgroup_size)
+            )
+
+    col_sub_sizes: list[int] = []
+    col_super_labels: list[int] = []
+    col_sub_labels: list[int] = []
+    for super_id, super_size in enumerate(col_super_sizes):
+        sizes = split_sizes(
+            int(super_size),
+            family.col_subgroups_per_super,
+            size.col_sub_min,
+            rng,
+        )
+        for local_sub, subgroup_size in enumerate(sizes):
+            col_sub_sizes.append(int(subgroup_size))
+            col_super_labels.extend([super_id] * int(subgroup_size))
+            col_sub_labels.extend(
+                [super_id * family.col_subgroups_per_super + local_sub]
+                * int(subgroup_size)
+            )
+
+    row_sub_ranges = subgroup_intervals(np.array(row_sub_sizes, dtype=int))
+    col_sub_ranges = subgroup_intervals(np.array(col_sub_sizes, dtype=int))
+    matrix = np.zeros((size.n_rows, size.n_cols), dtype=float)
+
+    unique_prototypes: dict[tuple[int, int], np.ndarray] = {}
+    shared_prototypes: dict[int, np.ndarray] = {}
+    cross_prototypes: dict[int, np.ndarray] = {}
+    for super_id in range(SUPER_BLOCKS):
+        col_base = super_id * family.col_subgroups_per_super
+        for local_sub in range(ROW_SUBGROUPS_PER_SUPER):
+            unique_cols = np.arange(*col_sub_ranges[col_base + local_sub], dtype=int)
+            unique_prototypes[(super_id, local_sub)] = choose_prototype(
+                unique_cols,
+                family.unique_keep,
+                rng,
+            )
+        if family.col_subgroups_per_super >= 3:
+            shared_cols = np.arange(*col_sub_ranges[col_base + 2], dtype=int)
+            shared_prototypes[super_id] = choose_prototype(
+                shared_cols,
+                family.shared_keep,
+                rng,
+            )
+        else:
+            shared_prototypes[super_id] = np.array([], dtype=int)
+
+    if family.cross_keep > 0:
+        for super_id in range(SUPER_BLOCKS):
+            next_super = (super_id + 1) % SUPER_BLOCKS
+            cross_prototypes[super_id] = shared_prototypes[next_super]
+    else:
+        cross_prototypes = {
+            super_id: np.array([], dtype=int) for super_id in range(SUPER_BLOCKS)
+        }
+
+    for global_row_sub, (row_start, row_stop) in enumerate(row_sub_ranges):
+        super_id = global_row_sub // ROW_SUBGROUPS_PER_SUPER
+        local_row_sub = global_row_sub % ROW_SUBGROUPS_PER_SUPER
+        pair_local = 1 - local_row_sub
+
+        primary_proto = unique_prototypes[(super_id, local_row_sub)]
+        paired_proto = choose_prototype(
+            unique_prototypes[(super_id, pair_local)],
+            family.paired_keep,
+            rng,
+        )
+        shared_proto = shared_prototypes[super_id]
+        cross_proto = cross_prototypes[super_id]
+        targeted = np.unique(
+            np.concatenate(
+                [
+                    primary_proto,
+                    paired_proto,
+                    shared_proto,
+                    cross_proto,
+                ]
+            )
+        )
+        all_cols = np.arange(size.n_cols, dtype=int)
+        non_target_cols = np.setdiff1d(all_cols, targeted, assume_unique=False)
+
+        for row_index in range(row_start, row_stop):
+            add_weighted_hits(
+                matrix,
+                row_index,
+                primary_proto,
+                family.unique_prob,
+                family.unique_lambda,
+                rng,
+            )
+            add_weighted_hits(
+                matrix,
+                row_index,
+                paired_proto,
+                family.paired_prob,
+                family.paired_lambda,
+                rng,
+            )
+            add_weighted_hits(
+                matrix,
+                row_index,
+                shared_proto,
+                family.shared_prob,
+                family.shared_lambda,
+                rng,
+            )
+            add_weighted_hits(
+                matrix,
+                row_index,
+                cross_proto,
+                family.cross_prob,
+                family.cross_lambda,
+                rng,
+            )
+            noise_low, noise_high = family.off_target_choices
+            if noise_high > 0 and len(non_target_cols) > 0:
+                noise_count = int(rng.integers(noise_low, noise_high + 1))
+                if noise_count > 0:
+                    noise_targets = rng.choice(
+                        non_target_cols,
+                        size=min(noise_count, len(non_target_cols)),
+                        replace=False,
+                    )
+                    matrix[row_index, noise_targets] += 1 + rng.poisson(
+                        family.off_target_lambda,
+                        len(noise_targets),
+                    )
+
+    row_perm = rng.permutation(size.n_rows)
+    col_perm = rng.permutation(size.n_cols)
+    observed = matrix[row_perm][:, col_perm]
+
+    return {
+        "ground_truth": matrix,
+        "observed": observed,
+        "row_perm": row_perm,
+        "col_perm": col_perm,
+        "row_super_labels": np.array(row_super_labels, dtype=int),
+        "row_sub_labels": np.array(row_sub_labels, dtype=int),
+        "col_super_labels": np.array(col_super_labels, dtype=int),
+        "col_sub_labels": np.array(col_sub_labels, dtype=int),
+    }
+
+
+def save_case_payload(
+    family: FamilySpec,
+    size: SizeSpec,
+    seed: int,
+    payload: dict[str, np.ndarray],
+) -> Path:
+    stem = CASE_DIR / f"{family.key}_{size.key}_seed{seed:02d}"
+    np.savez_compressed(stem.with_suffix(".npz"), **payload)
+    metadata = {
+        "family": family.key,
+        "size": size.key,
+        "seed": seed,
+        "shape": list(payload["observed"].shape),
+        "nnz_observed": int(np.count_nonzero(payload["observed"])),
+        "nnz_ground_truth": int(np.count_nonzero(payload["ground_truth"])),
+        "params": asdict(family),
+    }
+    stem.with_suffix(".json").write_text(
+        json.dumps(metadata, indent=2),
+        encoding="utf-8",
+    )
+    return stem.with_suffix(".npz")
+
+
+def save_case_catalog(rows: list[dict[str, object]]) -> None:
+    pd.DataFrame.from_records(rows).to_csv(
+        PROCESSED_DIR / "synthetic_case_catalog.csv",
+        index=False,
+    )
+
+
+def plot_representative_heatmaps(
+    representative_store: dict[str, dict[str, np.ndarray]],
+) -> None:
+    columns = ("Ground truth", "Observed", "Marginal", "HC+OLO", "One-walk", "TW")
+    fig, axes = plt.subplots(
+        len(FAMILIES),
+        len(columns),
+        figsize=(24, 14),
+        constrained_layout=True,
+    )
+    for row_index, family in enumerate(FAMILIES):
+        matrices = representative_store[family.key]
+        positive = np.concatenate(
+            [matrix[matrix > 0] for matrix in matrices.values() if np.any(matrix > 0)]
+        )
+        norm = LogNorm(vmin=float(np.min(positive)), vmax=float(np.max(positive)))
+        for col_index, column in enumerate(columns):
+            ax = axes[row_index, col_index]
+            matrix = np.ma.masked_where(matrices[column] <= 0, matrices[column])
+            image = ax.imshow(
+                matrix,
+                aspect="auto",
+                interpolation="nearest",
+                cmap="YlGnBu",
+                norm=norm,
+            )
+            if row_index == 0:
+                ax.set_title(column, fontsize=13)
+            if col_index == 0:
+                ax.set_ylabel(family.name, fontsize=11)
+            ax.set_xticks([])
+            ax.set_yticks([])
+            fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+    fig.suptitle("Synthetic rectangular benchmark (medium size, seed 0)", fontsize=16)
+    fig.savefig(
+        FIGURES_DIR / "synthetic_representative_heatmaps.png",
+        dpi=300,
+        bbox_inches="tight",
+    )
+    plt.close(fig)
+
+
+def plot_representative_tw_mosaic(
+    representative_store: dict[str, dict[str, np.ndarray]],
+) -> None:
+    fig, axes = plt.subplots(1, len(FAMILIES), figsize=(20, 5), constrained_layout=True)
+    for ax, family in zip(axes, FAMILIES, strict=True):
+        tw_matrix = representative_store[family.key]["TW"]
+        positive = tw_matrix[tw_matrix > 0]
+        mosaic_heatmap(
+            tw_matrix,
+            ax=ax,
+            xticklabels=False,
+            yticklabels=False,
+            cmap="YlGnBu",
+            norm=LogNorm(vmin=float(np.min(positive)), vmax=float(np.max(positive))),
+            cbar=True,
+            cbar_kws={"label": "Synthetic edge weight"},
+            rasterized=True,
+        )
+        ax.set_title(f"{family.name}\nTW + Mosaic", fontsize=12)
+        ax.set_xlabel("Column bins")
+        ax.set_ylabel("Row bins")
+        ax.xaxis.set_ticks_position("top")
+    fig.savefig(
+        FIGURES_DIR / "synthetic_tw_mosaic.png",
+        dpi=300,
+        bbox_inches="tight",
+    )
+    plt.close(fig)
+
+
+def plot_mwb_curves(
+    curve_store: dict[tuple[str, str], dict[str, np.ndarray]],
+) -> None:
+    fig, axes = plt.subplots(
+        len(SIZES),
+        len(FAMILIES),
+        figsize=(20, 10),
+        constrained_layout=True,
+    )
+    for row_index, size in enumerate(SIZES):
+        for col_index, family in enumerate(FAMILIES):
+            ax = axes[row_index, col_index]
+            curves = curve_store[(family.key, size.key)]
+            for method in METHOD_ORDER:
+                ax.plot(WIDTH_GRID, curves[method], label=method, linewidth=1.8)
+            if row_index == 0:
+                ax.set_title(family.name, fontsize=11)
+            if col_index == 0:
+                ax.set_ylabel(f"{size.name}\nMass within band", fontsize=10)
+            if row_index == len(SIZES) - 1:
+                ax.set_xlabel("Band width fraction")
+            ax.set_ylim(0, 1.02)
+            ax.grid(alpha=0.25)
+    axes[0, -1].legend(loc="lower right", fontsize=8)
+    fig.savefig(
+        FIGURES_DIR / "synthetic_mwb_curves.png",
+        dpi=300,
+        bbox_inches="tight",
+    )
+    plt.close(fig)
+
+
+def save_metric_tables(records: list[dict[str, object]]) -> None:
+    df = pd.DataFrame.from_records(records)
+    df.to_csv(PROCESSED_DIR / "synthetic_metrics.csv", index=False)
+
+    grouped = (
+        df.groupby(
+            ["family", "family_key", "size", "size_key", "method"],
+            as_index=False,
+        )
+        .agg(
+            two_sum_mean=("two_sum", "mean"),
+            two_sum_std=("two_sum", "std"),
+            band_mass_05_mean=("band_mass_05", "mean"),
+            band_mass_10_mean=("band_mass_10", "mean"),
+            band_mass_20_mean=("band_mass_20", "mean"),
+            mwb_auc_mean=("mwb_auc", "mean"),
+            ari_sub_mean=("ari_sub_mean", "mean"),
+            nmi_sub_mean=("nmi_sub_mean", "mean"),
+            ari_super_mean=("ari_super_mean", "mean"),
+            nmi_super_mean=("nmi_super_mean", "mean"),
+            runtime_mean=("runtime_s", "mean"),
+        )
+    )
+    grouped.to_csv(PROCESSED_DIR / "synthetic_summary.csv", index=False)
+
+    family_grouped = (
+        df.groupby(["family", "family_key", "method"], as_index=False)
+        .agg(
+            two_sum_mean=("two_sum", "mean"),
+            band_mass_10_mean=("band_mass_10", "mean"),
+            mwb_auc_mean=("mwb_auc", "mean"),
+            ari_sub_mean=("ari_sub_mean", "mean"),
+            nmi_sub_mean=("nmi_sub_mean", "mean"),
+            ari_super_mean=("ari_super_mean", "mean"),
+            nmi_super_mean=("nmi_super_mean", "mean"),
+        )
+    )
+    family_grouped.to_csv(PROCESSED_DIR / "synthetic_family_summary.csv", index=False)
+
+    lines = [
+        "# Synthetic Rectangular Benchmark Summary",
+        "",
+        (
+            "| Family | Size | Method | 2-SUM | Band@10% | MWB-AUC | "
+            "ARI(sub) | NMI(sub) | ARI(super) | NMI(super) | Runtime (s) |"
+        ),
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    sorted_grouped = grouped.sort_values(["family", "size", "method"])
+    for row in sorted_grouped.itertuples(index=False):
+        lines.append(
+            f"| {row.family} | {row.size} | {row.method} | {row.two_sum_mean:.6f} | "
+            f"{row.band_mass_10_mean:.3f} | {row.mwb_auc_mean:.3f} | "
+            f"{row.ari_sub_mean:.3f} | {row.nmi_sub_mean:.3f} | "
+            f"{row.ari_super_mean:.3f} | {row.nmi_super_mean:.3f} | "
+            f"{row.runtime_mean:.3f} |"
+        )
+    (PROCESSED_DIR / "synthetic_summary.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    ensure_directories()
+
+    reorderers = {
+        "Marginal": marginal_sort_reorder,
+        "HC+OLO": hierarchical_olo_reorder,
+        "One-walk": one_walk_reorder,
+        "TW": tw_reorder,
+    }
+
+    records: list[dict[str, object]] = []
+    curve_accumulator: dict[tuple[str, str], dict[str, list[np.ndarray]]] = {
+        (family.key, size.key): {method: [] for method in METHOD_ORDER}
+        for family in FAMILIES
+        for size in SIZES
+    }
+    representative_store: dict[str, dict[str, np.ndarray]] = {}
+    case_catalog: list[dict[str, object]] = []
+
+    for family in FAMILIES:
+        for size in SIZES:
+            for seed in range(NUM_SEEDS):
+                payload = build_case(family, size, seed)
+                case_path = save_case_payload(family, size, seed, payload)
+                case_catalog.append(
+                    {
+                        "family": family.key,
+                        "size": size.key,
+                        "seed": seed,
+                        "case_path": str(case_path.relative_to(REPO_ROOT)),
+                        "shape": (
+                            f"{payload['observed'].shape[0]}x"
+                            f"{payload['observed'].shape[1]}"
+                        ),
+                        "nnz_observed": int(np.count_nonzero(payload["observed"])),
+                        "nnz_ground_truth": int(
+                            np.count_nonzero(payload["ground_truth"])
+                        ),
+                    }
+                )
+
+                observed = payload["observed"]
+                observed_row_sub = payload["row_sub_labels"][payload["row_perm"]]
+                observed_col_sub = payload["col_sub_labels"][payload["col_perm"]]
+                observed_row_super = payload["row_super_labels"][payload["row_perm"]]
+                observed_col_super = payload["col_super_labels"][payload["col_perm"]]
+
+                results: dict[str, ReorderResult] = {
+                    "Original": ReorderResult(
+                        observed.copy(),
+                        np.arange(observed.shape[0], dtype=int),
+                        np.arange(observed.shape[1], dtype=int),
+                    )
+                }
+                runtimes = {"Original": 0.0}
+
+                for method, reorder in reorderers.items():
+                    start = time.perf_counter()
+                    result = reorder(observed)
+                    runtimes[method] = time.perf_counter() - start
+                    results[method] = result
+
+                curves = compute_curves(
+                    {method: result.matrix for method, result in results.items()},
+                    WIDTH_GRID,
+                )
+                for method in METHOD_ORDER:
+                    curve_accumulator[(family.key, size.key)][method].append(
+                        curves[method]
+                    )
+                    result = results[method]
+                    matrix = result.matrix
+                    sub_scores = contiguous_cluster_scores(
+                        matrix,
+                        observed_row_sub[result.row_order],
+                        observed_col_sub[result.col_order],
+                    )
+                    super_scores = contiguous_cluster_scores(
+                        matrix,
+                        observed_row_super[result.row_order],
+                        observed_col_super[result.col_order],
+                    )
+                    records.append(
+                        {
+                            "family": family.name,
+                            "family_key": family.key,
+                            "size": size.name,
+                            "size_key": size.key,
+                            "seed": seed,
+                            "method": method,
+                            "shape": f"{matrix.shape[0]}x{matrix.shape[1]}",
+                            "two_sum": normalized_two_sum(matrix),
+                            "band_mass_05": diagonal_band_mass(matrix, 0.05),
+                            "band_mass_10": diagonal_band_mass(matrix, 0.10),
+                            "band_mass_20": diagonal_band_mass(matrix, 0.20),
+                            "mwb_auc": mwb_auc(matrix, WIDTH_GRID),
+                            "ari_sub_row": sub_scores["ari_row"],
+                            "ari_sub_col": sub_scores["ari_col"],
+                            "ari_sub_mean": sub_scores["ari_mean"],
+                            "nmi_sub_row": sub_scores["nmi_row"],
+                            "nmi_sub_col": sub_scores["nmi_col"],
+                            "nmi_sub_mean": sub_scores["nmi_mean"],
+                            "ari_super_row": super_scores["ari_row"],
+                            "ari_super_col": super_scores["ari_col"],
+                            "ari_super_mean": super_scores["ari_mean"],
+                            "nmi_super_row": super_scores["nmi_row"],
+                            "nmi_super_col": super_scores["nmi_col"],
+                            "nmi_super_mean": super_scores["nmi_mean"],
+                            "runtime_s": runtimes[method],
+                        }
+                    )
+
+                if size.key == "medium" and seed == 0:
+                    representative_store[family.key] = {
+                        "Ground truth": payload["ground_truth"],
+                        "Observed": observed,
+                        "Marginal": results["Marginal"].matrix,
+                        "HC+OLO": results["HC+OLO"].matrix,
+                        "One-walk": results["One-walk"].matrix,
+                        "TW": results["TW"].matrix,
+                    }
+
+    curve_store = {
+        (family.key, size.key): {
+            method: np.mean(curve_accumulator[(family.key, size.key)][method], axis=0)
+            for method in METHOD_ORDER
+        }
+        for family in FAMILIES
+        for size in SIZES
+    }
+
+    save_case_catalog(case_catalog)
+    save_metric_tables(records)
+    plot_representative_heatmaps(representative_store)
+    plot_representative_tw_mosaic(representative_store)
+    plot_mwb_curves(curve_store)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/rectangular_evaluation/README.md
+++ b/data/rectangular_evaluation/README.md
@@ -1,0 +1,20 @@
+Outputs for the rectangular evaluation suite.
+
+- Real-data benchmark:
+  - `Original`
+  - `Marginal`
+  - `HC+OLO`
+  - `One-walk`
+  - `TW`
+- Synthetic benchmark:
+  - `5` synthetic families
+  - `3` sizes (`Small`, `Medium`, `Large`)
+  - saved `.npz` cases with ground-truth block labels
+  - summary tables with `2-SUM`, band mass, `MWB-AUC`, `ARI`, and `NMI`
+- Synthetic alpha sweep:
+  - `synthetic_alpha_sweep.csv`
+  - `synthetic_alpha_summary.csv`
+  - `synthetic_alpha_best.csv`
+  - `synthetic_alpha_best.md`
+  - `synthetic_alpha_family_best.csv`
+  - `synthetic_alpha_sweep_mwb_auc.png`


### PR DESCRIPTION
## Summary

This PR adds a rectangular-matrix benchmark suite for evaluating spectral reordering methods on real and synthetic datasets.

The focus is on rectangular / bipartite matrices where row and column semantics differ.

## Included

### Real-data matrix construction
These scripts build the three rectangular real-data matrices used by the benchmark:

- `Examples/_rectangular_tw_common.py`
  - shared utilities for rectangular matrix demos and plotting
- `Examples/naics_sic_rectangular/demo_tw_mosaic.py`
  - downloads and builds the `1987 SIC -> 2002 NAICS` rectangular mapping matrix
- `Examples/acs_pums_rectangular/demo_tw_mosaic.py`
  - downloads and builds the `ACS 2023 Massachusetts PUMS` occupation-by-industry matrix
- `Examples/lodes_rectangular/demo_tw_mosaic.py`
  - downloads and builds the `Tennessee LODES 2022` home-county by work-county flow matrix

### Evaluation code
These files implement the benchmark workflow:

- `Examples/rectangular_evaluation/_benchmark_utils.py`
  - shared benchmark helpers
  - reordering wrappers
  - metric computation
  - contiguous ARI/NMI recovery utilities
- `Examples/rectangular_evaluation/run_realdata_evaluation.py`
  - runs the real-data benchmark on the three rectangular datasets
  - compares `Original`, `Marginal`, `HC+OLO`, `One-walk`, and `TW`
- `Examples/rectangular_evaluation/run_synthetic_evaluation.py`
  - generates synthetic rectangular benchmark families
  - runs the same method comparison across multiple sizes and seeds
- `Examples/rectangular_evaluation/run_synthetic_alpha_sweep.py`
  - evaluates `TW(alpha)` against `One-walk` on the synthetic benchmark
- `Examples/rectangular_evaluation/make_synthetic_results_table.py`
  - converts benchmark summaries into paper-ready LaTeX tables

### Documentation
- `Examples/rectangular_evaluation/README.md`
  - explains the benchmark workflow and how to run the scripts
- `data/rectangular_evaluation/README.md`
  - documents the expected output structure under `data/rectangular_evaluation/`

## Methods compared

The benchmark compares:

- `Original`
- `Marginal`
- `HC+OLO`
- `One-walk`
- `TW`
- `TW(alpha)` for synthetic alpha sweeps

## Metrics

The evaluation supports:

- `2-SUM`
- `MWB-AUC`
- `Runtime`
- `ARI`
- `NMI`

For the synthetic benchmark, ARI/NMI are computed from contiguous subgroup recovery induced by the reordered matrix.

## Notes

- This PR does **not** modify `src/` or `tests/`.
- This PR includes benchmark code and workflow only.
- Generated result files are intentionally excluded.
